### PR TITLE
chore(repo): refine pull request guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,6 @@
 ## Linear
 
-<!-- Use `Fixes AET-123` when this PR completes the issue. Use `Refs AET-123` for partial work. -->
-
-Refs AET-
+<!-- Replace this comment with `Fixes AET-123` when this PR completes the issue, or `Refs AET-123` for partial work. -->
 
 ## Summary
 
@@ -12,7 +10,8 @@ Refs AET-
 
 - [ ] Focused tests pass
 - [ ] Type checking passes
-- [ ] Consumer-facing changes include documentation and a Changeset, or neither is required
+- [ ] Meaningful consumer-facing changes include a Changeset, or no Changeset is required
+- [ ] Documentation is updated when required, or no documentation change is needed
 - [ ] Existing coverage was not weakened or skipped
 
 ## Visual evidence


### PR DESCRIPTION
## Linear

Refs AET-19

## Summary

- hide the Linear example until an author supplies valid issue metadata
- separate Changeset and documentation decisions in the verification checklist

## Verification

- [x] Focused template assertions pass
- [x] Type checking is not applicable to this Markdown-only change
- [x] No Changeset is required for repository-only guidance
- [x] Documentation requirements were evaluated independently
- [x] Existing coverage was not weakened or skipped

## Visual evidence

Not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request guidance to clarify when to use “Fixes” versus “Refs” for work items.
  * Revised the verification checklist to clarify requirements for consumer-facing changes and Changesets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->