### PR TITLE
fix(studio): protect external source changes

### DIFF
--- a/.changeset/safe-studios-save.md
+++ b/.changeset/safe-studios-save.md
@@ -1,0 +1,5 @@
+---
+"@scribe-sdk/cli": patch
+---
+
+Prevent Scribe Studio from overwriting source changed by an external editor by revalidating the file immediately before save. Preserve unsaved drafts when the source is deleted or renamed, reload explicitly from current disk content, and retain the article's LF or CRLF line endings.

--- a/packages/cli/src/studio.test.ts
+++ b/packages/cli/src/studio.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer as createNetServer } from "node:net";
@@ -258,6 +258,89 @@ it("detects external changes and refuses to overwrite an unsaved draft", async (
   });
   expect(saved.status).toBe(409);
   expect(await readFile(file.path, "utf8")).toBe("# External editor change\n");
+
+  const reloaded = await fetch(`${handle.origin}/__scribe/api/discard`, { method: "POST" });
+  expect(reloaded.status).toBe(200);
+  await expect(reloaded.json()).resolves.toMatchObject({
+    source: "# External editor change\n",
+    dirty: false,
+    conflict: false
+  });
+});
+
+it("revalidates the source on disk immediately before saving", async () => {
+  const file = await fixture();
+  const handle = await startStudio({ root: file.root, path: file.path, mode: "default", port: 0, open: false });
+  handles.push(handle);
+  const initial = await (await fetch(`${handle.origin}/__scribe/api/document`)).json() as { diskVersion: string };
+
+  await fetch(`${handle.origin}/__scribe/api/draft`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ source: "# Unsaved studio draft\n" })
+  });
+  await writeFile(file.path, "# External editor change before watcher delivery\n");
+
+  const saved = await fetch(`${handle.origin}/__scribe/api/save`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ expectedDiskVersion: initial.diskVersion })
+  });
+
+  expect(saved.status).toBe(409);
+  await expect(saved.json()).resolves.toMatchObject({
+    conflict: true,
+    error: expect.stringContaining("changed outside Studio")
+  });
+  expect(await readFile(file.path, "utf8")).toBe("# External editor change before watcher delivery\n");
+});
+
+it("keeps the draft conflicted when reload cannot read a deleted source", async () => {
+  const file = await fixture();
+  const handle = await startStudio({ root: file.root, path: file.path, mode: "default", port: 0, open: false });
+  handles.push(handle);
+
+  await fetch(`${handle.origin}/__scribe/api/draft`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ source: "# Unsaved studio draft\n" })
+  });
+  await unlink(file.path);
+  await expect.poll(async () => {
+    const state = await (await fetch(`${handle.origin}/__scribe/api/document`)).json() as { conflict: boolean };
+    return state.conflict;
+  }).toBe(true);
+
+  const reloaded = await fetch(`${handle.origin}/__scribe/api/discard`, { method: "POST" });
+
+  expect(reloaded.status).toBe(409);
+  await expect(reloaded.json()).resolves.toMatchObject({
+    conflict: true,
+    dirty: true,
+    source: "# Unsaved studio draft\n",
+    error: expect.stringContaining("deleted or renamed")
+  });
+});
+
+it("preserves CRLF line endings when a draft is saved", async () => {
+  const file = await fixture("crlf.mdx", "# Peer states\r\n\r\nOriginal.\r\n");
+  const handle = await startStudio({ root: file.root, path: file.path, mode: "default", port: 0, open: false });
+  handles.push(handle);
+  const initial = await (await fetch(`${handle.origin}/__scribe/api/document`)).json() as { diskVersion: string };
+
+  await fetch(`${handle.origin}/__scribe/api/draft`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ source: "# Peer states\n\nUpdated.\n" })
+  });
+  const saved = await fetch(`${handle.origin}/__scribe/api/save`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ expectedDiskVersion: initial.diskVersion })
+  });
+
+  expect(saved.status).toBe(200);
+  expect(await readFile(file.path, "utf8")).toBe("# Peer states\r\n\r\nUpdated.\r\n");
 });
 
 it("rejects source and host CSS paths outside the selected workspace", async () => {

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -150,7 +150,7 @@ export async function startStudio(options: StudioOptions): Promise<StudioHandle>
     previewVersion: 1,
     mode: options.mode,
     modeReason: options.modeReason ?? "Selected explicitly by the Studio caller.",
-    lineEnding: diskSource.includes("\r\n") ? "\r\n" : "\n",
+    lineEnding: detectLineEnding(diskSource),
     dirty: false,
     conflict: false,
     diagnostics: await diagnosticsFor(sourcePath, diskSource),
@@ -224,7 +224,7 @@ export async function startStudio(options: StudioOptions): Promise<StudioHandle>
     const wasClean = !state.dirty;
     state.diskSource = source;
     state.diskVersion = fingerprint(source);
-    state.lineEnding = source.includes("\r\n") ? "\r\n" : "\n";
+    state.lineEnding = detectLineEnding(source);
     if (wasClean) {
       state.draftSource = source;
       state.previewSource = source;
@@ -240,11 +240,7 @@ export async function startStudio(options: StudioOptions): Promise<StudioHandle>
   server.watcher.on("unlink", (path) => {
     if (resolve(path) !== sourcePath) return;
     state.conflict = true;
-    state.diagnostics = [{
-      severity: "error",
-      code: "SCB2001",
-      message: "The source file was deleted or renamed outside Studio. Save is blocked until it is restored or the session is closed."
-    }];
+    state.diagnostics = [missingSourceDiagnostic()];
   });
 
   const address = httpServer.address();
@@ -432,7 +428,23 @@ function createStudioPlugin(context: {
         if (url.pathname === "/__scribe/api/save" && request.method === "PUT") {
           try {
             const body = await readJsonBody(request) as { expectedDiskVersion?: unknown };
-            if (body.expectedDiskVersion !== context.state.diskVersion || context.state.conflict) {
+            let diskSource: string;
+            try {
+              diskSource = await readUtf8(context.sourcePath);
+            } catch {
+              context.state.conflict = true;
+              context.state.diagnostics = [missingSourceDiagnostic()];
+              return json(response, 409, {
+                error: "The source file was deleted or renamed outside Studio. Restore it before saving.",
+                ...publicState(context.state)
+              });
+            }
+            const diskVersion = fingerprint(diskSource);
+            if (body.expectedDiskVersion !== context.state.diskVersion || context.state.conflict || diskVersion !== body.expectedDiskVersion) {
+              context.state.diskSource = diskSource;
+              context.state.diskVersion = diskVersion;
+              context.state.lineEnding = detectLineEnding(diskSource);
+              context.state.conflict = true;
               return json(response, 409, { error: "The source changed outside Studio. Reload or reconcile before saving.", ...publicState(context.state) });
             }
             await atomicWrite(context.sourcePath, context.state.draftSource);
@@ -446,11 +458,25 @@ function createStudioPlugin(context: {
           }
         }
         if (url.pathname === "/__scribe/api/discard" && request.method === "POST") {
-          context.state.draftSource = context.state.diskSource;
-          context.state.previewSource = context.state.diskSource;
+          let diskSource: string;
+          try {
+            diskSource = await readUtf8(context.sourcePath);
+          } catch {
+            context.state.conflict = true;
+            context.state.diagnostics = [missingSourceDiagnostic()];
+            return json(response, 409, {
+              error: "The source file was deleted or renamed outside Studio. The unsaved draft is still preserved.",
+              ...publicState(context.state)
+            });
+          }
+          context.state.diskSource = diskSource;
+          context.state.diskVersion = fingerprint(diskSource);
+          context.state.lineEnding = detectLineEnding(diskSource);
+          context.state.draftSource = diskSource;
+          context.state.previewSource = diskSource;
           context.state.dirty = false;
           context.state.conflict = false;
-          context.state.diagnostics = await diagnosticsFor(context.sourcePath, context.state.diskSource);
+          context.state.diagnostics = await diagnosticsFor(context.sourcePath, diskSource);
           context.state.previewVersion += 1;
           context.state.revision += 1;
           context.state.richProjection = undefined;
@@ -699,6 +725,18 @@ function frontmatter(source: string): Record<string, string> {
 
 function normalizeLineEndings(source: string, ending: "\n" | "\r\n"): string {
   return source.replace(/\r\n?|\n/gu, "\n").replaceAll("\n", ending);
+}
+
+function detectLineEnding(source: string): "\n" | "\r\n" {
+  return source.includes("\r\n") ? "\r\n" : "\n";
+}
+
+function missingSourceDiagnostic(): StudioDiagnostic {
+  return {
+    severity: "error",
+    code: "SCB2001",
+    message: "The source file was deleted or renamed outside Studio. Save is blocked until it is restored or the session is closed."
+  };
 }
 
 async function readUtf8(path: string): Promise<string> {

--- a/tests/studio-browser/studio.spec.ts
+++ b/tests/studio-browser/studio.spec.ts
@@ -1,8 +1,29 @@
 import { expect, test } from "@playwright/test";
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const fixturePath = resolve("tests/fixtures/studio-article.mdx");
+let originalFixture = "";
+
+test.beforeAll(async () => {
+  originalFixture = await readFile(fixturePath, "utf8");
+});
+
+test.afterAll(async () => {
+  if (originalFixture) await writeFile(fixturePath, originalFixture, "utf8");
+});
 
 test("keeps Markdown canonical while constrained Rich Text edits update the mirror and production preview", async ({ page }, testInfo) => {
   const issues: string[] = [];
-  page.on("console", (message) => { if (message.type() === "error") issues.push(message.text()); });
+  let expectedConflictResponse = false;
+  page.on("console", (message) => {
+    if (message.type() !== "error") return;
+    if (expectedConflictResponse && message.text().includes("409 (Conflict)")) {
+      expectedConflictResponse = false;
+      return;
+    }
+    issues.push(message.text());
+  });
   page.on("pageerror", (error) => issues.push(error.message));
 
   await page.goto("/");
@@ -75,6 +96,25 @@ test("keeps Markdown canonical while constrained Rich Text edits update the mirr
   await expect(page.locator(".preview-device__label")).toContainText("Mobile · 414 × 896");
   await page.getByRole("button", { name: "Dark" }).click();
   await expect(preview.locator(".scribe[data-theme='dark']")).toBeVisible();
+
+  const externalSource = "# External editor version\n\nThis change came from the IDE.\n";
+  await writeFile(fixturePath, externalSource, "utf8");
+  await expect(page.getByRole("alert").filter({ hasText: "Source changed outside Studio" })).toBeVisible();
+  await expect(source).not.toHaveValue(externalSource);
+
+  expectedConflictResponse = true;
+  await page.getByRole("button", { name: /^Save/u }).click();
+  expect(await readFile(fixturePath, "utf8")).toBe(externalSource);
+  await expect(page.locator("[data-sonner-toast]")).toContainText("changed outside Studio");
+  expect(expectedConflictResponse).toBe(false);
+
+  await page.getByRole("button", { name: "Reload from disk" }).click();
+  await expect(source).toHaveValue(externalSource);
+  await expect(page.getByRole("alert").filter({ hasText: "Source changed outside Studio" })).toHaveCount(0);
+  await expect(page.locator("#status-text")).toHaveText("Ready");
+
+  await writeFile(fixturePath, originalFixture, "utf8");
+  await expect(source).toHaveValue(/Peer state transitions/u);
 
   expect(issues).toEqual([]);
 });


### PR DESCRIPTION
## Linear

Fixes AET-15

## Summary

- revalidate the source file immediately before Studio saves
- preserve the unsaved draft when the source is deleted or renamed
- reload explicitly from current disk content and retain LF/CRLF style
- cover the external-edit conflict through the Studio browser flow

## Verification

- [x] `bunx vitest run packages/cli/src/studio.test.ts` (13 tests)
- [x] `bunx vitest run packages/cli/src` (43 tests)
- [x] `bun run --cwd packages/cli build`
- [x] `bun run typecheck`
- [x] `bun run test:studio:browser -- --project=chromium`
- [x] `bunx changeset status`
- [x] `git diff --check`
- [x] Added a Changeset for the consumer-visible CLI fix
- [x] Documentation is unchanged because the existing explicit-save contract remains accurate
- [x] Existing coverage was not weakened or skipped

## Visual evidence

Not applicable — this changes filesystem safety behavior without changing Studio presentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Studio now detects external file changes immediately before saving to prevent overwriting newer edits.
  * Unsaved drafts are preserved when the source file is deleted or renamed.
  * Reloading from disk now reliably clears conflicts and updates the editor and preview.
  * Saved files preserve their existing LF or CRLF line-ending format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->