### PR TITLE
fix(studio): preserve protected rich text source

### DIFF
--- a/.changeset/precise-studios-protect.md
+++ b/.changeset/precise-studios-protect.md
@@ -1,0 +1,5 @@
+---
+"@scribe-sdk/cli": patch
+---
+
+Keep constrained Rich Text mode source-safe by avoiding serialization when users switch modes without editing, preserving protected MDX islands byte-for-byte, and naming the exact JSX, frontmatter, import, export, expression, comment, directive, or code metadata construct when an unsafe edit is rejected.

--- a/packages/cli/src/rich-preservation.test.ts
+++ b/packages/cli/src/rich-preservation.test.ts
@@ -24,6 +24,19 @@ it("classifies unsafe MDX as ordered protected islands", async () => {
     "codeMetadata",
     "mdxJsxFlowElement"
   ]);
+  expect(projection.islands.map(({ label }) => label)).toEqual([
+    "frontmatter",
+    "MDX import",
+    "MDX export",
+    "MDX expression",
+    "<Badge>",
+    "<Callout>",
+    "<aside>",
+    "MDX comment",
+    ":::unknown-directive directive",
+    "code-fence metadata",
+    "<table>"
+  ]);
   expect(projection.islands.map(({ start, end }) => source.slice(start, end))).toEqual(
     projection.islands.map(({ raw }) => raw)
   );
@@ -67,6 +80,44 @@ it.each([
   const result = await acceptRichCandidate(projection, mutate(projection.projectionMarkdown), fixturePath);
 
   expect(result).toMatchObject({ ok: false, markdown: source });
+});
+
+it("identifies the exact protected construct removed by an unsafe edit", async () => {
+  const source = await readFile(fixturePath, "utf8");
+  const projection = await createRichProjection(source);
+
+  for (const island of projection.islands) {
+    const marker = new RegExp(`<ScribeStudioProtectedIsland[^>]+data-scribe-id=["']${island.id}["'][^>]*/>\\n*`, "u");
+    const result = await acceptRichCandidate(projection, projection.projectionMarkdown.replace(marker, ""), fixturePath);
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "SCB_RICH_PLACEHOLDER_MISSING",
+      islandId: island.id,
+      markdown: source
+    });
+    if (result.ok) throw new Error("Unsafe Rich Text edit was accepted.");
+    expect(result.message).toContain(island.label);
+  }
+});
+
+it("identifies a newly introduced unsupported construct without changing canonical Markdown", async () => {
+  const source = await readFile(fixturePath, "utf8");
+  const projection = await createRichProjection(source);
+  const candidate = projection.projectionMarkdown.replace(
+    "Editable paragraph.",
+    "Editable paragraph.\n\n<InjectedWidget data={experimental} />"
+  );
+
+  const result = await acceptRichCandidate(projection, candidate, fixturePath);
+
+  expect(result).toMatchObject({
+    ok: false,
+    code: "SCB_RICH_PROTECTED_CHANGED",
+    markdown: source
+  });
+  if (result.ok) throw new Error("Unsupported Rich Text construct was accepted.");
+  expect(result.message).toContain("<InjectedWidget>");
 });
 
 it("rejects a candidate that cannot compile and retains canonical Markdown", async () => {

--- a/packages/cli/src/rich-preservation.ts
+++ b/packages/cli/src/rich-preservation.ts
@@ -131,16 +131,26 @@ export async function acceptRichCandidate(
   }
   const duplicated = expectedIds.find((id) => (counts.get(id) ?? 0) > 1);
   if (duplicated) {
-    return reject(projection, "SCB_RICH_PLACEHOLDER_DUPLICATED", `Rich Text candidate duplicated protected block "${duplicated}".`, duplicated);
+    const island = projection.islands.find(({ id }) => id === duplicated)!;
+    return reject(projection, "SCB_RICH_PLACEHOLDER_DUPLICATED", `Rich Text candidate duplicated protected ${island.label}.`, duplicated);
   }
   const missing = expectedIds.find((id) => (counts.get(id) ?? 0) === 0);
   if (missing) {
-    return reject(projection, "SCB_RICH_PLACEHOLDER_MISSING", `Rich Text candidate removed protected block "${missing}".`, missing);
+    const island = projection.islands.find(({ id }) => id === missing)!;
+    return reject(projection, "SCB_RICH_PLACEHOLDER_MISSING", `Rich Text candidate removed protected ${island.label}.`, missing);
   }
   const actualIds = placeholders.map(({ id }) => id);
   if (actualIds.some((id, index) => id !== expectedIds[index])) {
     const firstMismatch = actualIds.find((id, index) => id !== expectedIds[index]);
-    return reject(projection, "SCB_RICH_PLACEHOLDER_REORDERED", "Rich Text candidate changed the order of protected source blocks.", firstMismatch);
+    const island = projection.islands.find(({ id }) => id === firstMismatch);
+    return reject(
+      projection,
+      "SCB_RICH_PLACEHOLDER_REORDERED",
+      island === undefined
+        ? "Rich Text candidate changed the order of protected source blocks."
+        : `Rich Text candidate changed the order of protected ${island.label}.`,
+      firstMismatch
+    );
   }
 
   const rehydrated = rehydrateCandidate(candidate, placeholders, projection.islands);
@@ -149,6 +159,23 @@ export async function acceptRichCandidate(
     rehydratedIslands = classifyProtectedIslands(rehydrated, parseMarkdown(rehydrated));
   } catch (error) {
     return reject(projection, "SCB_RICH_PARSE_FAILED", `Rehydrated Markdown could not be parsed: ${errorMessage(error)}`);
+  }
+  const expectedRawCounts = new Map<string, number>();
+  for (const island of projection.islands) {
+    expectedRawCounts.set(island.raw, (expectedRawCounts.get(island.raw) ?? 0) + 1);
+  }
+  const introduced = rehydratedIslands.find((island) => {
+    const remaining = expectedRawCounts.get(island.raw) ?? 0;
+    if (remaining === 0) return true;
+    expectedRawCounts.set(island.raw, remaining - 1);
+    return false;
+  });
+  if (introduced) {
+    return reject(
+      projection,
+      "SCB_RICH_PROTECTED_CHANGED",
+      `Rich Text candidate introduced unsupported ${introduced.label}.`
+    );
   }
   const changedIndex = projection.islands.findIndex((island, index) => rehydratedIslands[index]?.raw !== island.raw);
   if (changedIndex >= 0 || rehydratedIslands.length !== projection.islands.length) {
@@ -179,27 +206,31 @@ function parseMarkdown(markdown: string): MdastNode {
 function classifyProtectedIslands(markdown: string, tree: MdastNode): readonly ProtectedIsland[] {
   let islandIndex = 0;
   return (tree.children ?? []).flatMap((node) => {
-    const kind = protectedKind(node, markdown);
-    if (kind === undefined) return [];
+    const protectedNode = classifyProtectedNode(node, markdown);
+    if (protectedNode === undefined) return [];
     const range = nodeRange(node);
+    const raw = markdown.slice(range.start, range.end);
     const index = 1 + islandIndex++;
     return [{
       id: `scribe-protected-${String(index).padStart(4, "0")}`,
-      kind,
-      label: islandLabel(kind, node),
+      kind: protectedNode.kind,
+      label: islandLabel(protectedNode.kind, protectedNode.node, raw),
       ...range,
-      raw: markdown.slice(range.start, range.end)
+      raw
     }];
   });
 }
 
-function protectedKind(node: MdastNode, markdown: string): ProtectedIslandKind | undefined {
-  if (node.type === "yaml" || node.type === "toml") return "frontmatter";
-  if (node.type === "code" && (node.lang != null || node.meta != null)) return "codeMetadata";
+function classifyProtectedNode(
+  node: MdastNode,
+  markdown: string
+): { readonly kind: ProtectedIslandKind; readonly node: MdastNode } | undefined {
+  if (node.type === "yaml" || node.type === "toml") return { kind: "frontmatter", node };
+  if (node.type === "code" && (node.lang != null || node.meta != null)) return { kind: "codeMetadata", node };
   const raw = rawNode(markdown, node).trimStart();
-  if (isDirectiveNode(node) || raw.startsWith(":::")) return "directive";
+  if (isDirectiveNode(node) || raw.startsWith(":::")) return { kind: "directive", node };
   const unsafe = findUnsafeDescendant(node);
-  return unsafe === undefined ? undefined : kindForNode(unsafe);
+  return unsafe === undefined ? undefined : { kind: kindForNode(unsafe), node: unsafe };
 }
 
 function findUnsafeDescendant(node: MdastNode): MdastNode | undefined {
@@ -275,12 +306,22 @@ function rawNode(markdown: string, node: MdastNode): string {
   return markdown.slice(start, end);
 }
 
-function islandLabel(kind: ProtectedIslandKind, node: MdastNode): string {
+function islandLabel(kind: ProtectedIslandKind, node: MdastNode, raw: string): string {
   if (kind === "frontmatter") return "frontmatter";
   if (kind === "codeMetadata") return "code-fence metadata";
-  if (kind === "directive") return "directive";
-  if (kind === "mdxjsEsm") return "MDX import/export";
-  if (kind === "mdxFlowExpression" || kind === "mdxTextExpression") return "MDX expression";
+  if (kind === "directive") {
+    const name = node.name ?? /^\s*:::([A-Za-z][\w-]*)/u.exec(raw)?.[1];
+    return name === undefined ? "directive" : `:::${name} directive`;
+  }
+  if (kind === "mdxjsEsm") {
+    const value = node.value?.trimStart() ?? "";
+    if (value.startsWith("import ")) return "MDX import";
+    if (value.startsWith("export ")) return "MDX export";
+    return "MDX import/export";
+  }
+  if (kind === "mdxFlowExpression" || kind === "mdxTextExpression") {
+    return /^\/\*/u.test(node.value?.trimStart() ?? "") ? "MDX comment" : "MDX expression";
+  }
   if (kind === "mdxJsxFlowElement" || kind === "mdxJsxTextElement") {
     return node.name == null ? "MDX JSX" : `<${node.name}>`;
   }

--- a/packages/cli/src/studio-ui.ts
+++ b/packages/cli/src/studio-ui.ts
@@ -228,6 +228,7 @@ function RichEditor({ session, state, onAccepted, onRejected, onEditInMarkdown, 
   const lastAcceptedRef = useRef(session.projectionMarkdown);
   const timerRef = useRef();
   const submittingRef = useRef(false);
+  const pendingRef = useRef(false);
 
   const plugins = useMemo(() => [
     headingsPlugin({ allowedHeadingLevels: [1, 2, 3, 4] }),
@@ -260,14 +261,17 @@ function RichEditor({ session, state, onAccepted, onRejected, onEditInMarkdown, 
       if (response.ok) {
         revisionRef.current = body.revision;
         lastAcceptedRef.current = candidate;
+        pendingRef.current = false;
         onAccepted(body, { ...session, revision: body.revision, projectionMarkdown: body.projectionMarkdown, islands: body.islands });
         return true;
       }
       editorRef.current?.setMarkdown(lastAcceptedRef.current);
+      pendingRef.current = false;
       onRejected(body.error || "This Rich Text edit could not be represented safely.", body.islandId);
       return false;
     } catch (error) {
       editorRef.current?.setMarkdown(lastAcceptedRef.current);
+      pendingRef.current = false;
       onRejected(error instanceof Error ? error.message : "Studio could not validate this Rich Text edit.");
       return false;
     } finally {
@@ -277,7 +281,9 @@ function RichEditor({ session, state, onAccepted, onRejected, onEditInMarkdown, 
   }, [onAccepted, onPendingChange, onRejected, session]);
 
   useEffect(() => {
-    registerFlush(async () => submit(editorRef.current?.getMarkdown() || lastAcceptedRef.current));
+    registerFlush(async () => pendingRef.current
+      ? submit(editorRef.current?.getMarkdown() || lastAcceptedRef.current)
+      : true);
     return () => registerFlush(null);
   }, [registerFlush, submit]);
 
@@ -287,13 +293,16 @@ function RichEditor({ session, state, onAccepted, onRejected, onEditInMarkdown, 
       if (!response.ok) return onRejected(body.error || "Rich Text mode could not reload.");
       revisionRef.current = body.revision;
       lastAcceptedRef.current = body.projectionMarkdown;
+      pendingRef.current = false;
+      onPendingChange(false);
       editorRef.current?.setMarkdown(body.projectionMarkdown);
       onAccepted(state, { ...body, tab: session.tab }, false);
     });
-  }, [state.revision, onAccepted, onRejected, session.tab]);
+  }, [state.revision, onAccepted, onPendingChange, onRejected, session.tab]);
 
   const onChange = useCallback((candidate, initialNormalize) => {
     if (initialNormalize) return;
+    pendingRef.current = true;
     onPendingChange(true);
     clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => submit(candidate), 320);

--- a/packages/cli/src/studio.test.ts
+++ b/packages/cli/src/studio.test.ts
@@ -162,7 +162,7 @@ it("projects protected MDX for Rich Text mode and accepts only preservation-safe
     ok: false,
     code: "SCB_RICH_PLACEHOLDER_MISSING",
     source: expect.stringContaining("Edited paragraph."),
-    error: expect.stringContaining("protected block")
+    error: expect.stringContaining("protected frontmatter")
   });
   expect(await readFile(file.path, "utf8")).toBe(source);
 });

--- a/tests/studio-browser/studio.spec.ts
+++ b/tests/studio-browser/studio.spec.ts
@@ -67,7 +67,18 @@ test("keeps Markdown canonical while constrained Rich Text edits update the mirr
   await expect(preview.locator("h1#recovered-draft")).toBeVisible();
   await expect(page.locator("#status-text")).toHaveText("Unsaved draft");
 
-  await source.fill("# Recovered draft\n\nEditable paragraph.\n\n<Callout variant=\"note\">Protected note.</Callout>\n");
+  const richSource = "# Recovered draft\n\nEditable paragraph.\n\n<Callout variant=\"note\">Protected note.</Callout>\n";
+  await source.fill(richSource);
+  await expect.poll(async () => page.evaluate(async () => (await fetch("/__scribe/api/document")).json().then((value) => value.source))).toBe(richSource);
+  const beforeNoopSwitch = await page.evaluate(async () => (await fetch("/__scribe/api/document")).json());
+  await page.getByRole("button", { name: "Rich Text" }).click();
+  await expect(page.getByRole("toolbar", { name: "Rich Text formatting" })).toBeVisible();
+  await page.getByRole("button", { name: "Markdown", exact: true }).click();
+  await expect(page.getByRole("toolbar", { name: "Rich Text formatting" })).toHaveCount(0);
+  const afterNoopSwitch = await page.evaluate(async () => (await fetch("/__scribe/api/document")).json());
+  expect(afterNoopSwitch.source).toBe(beforeNoopSwitch.source);
+  expect(afterNoopSwitch.revision).toBe(beforeNoopSwitch.revision);
+
   await page.getByRole("button", { name: "Rich Text" }).click();
   await expect(page.getByRole("toolbar", { name: "Rich Text formatting" })).toBeVisible();
   await page.evaluate(() => document.fonts.ready);


### PR DESCRIPTION
## Linear

Fixes AET-16

## Summary

- preserve canonical Markdown when users enter and leave Rich Text without editing
- classify the exact protected JSX, import, export, expression, comment, directive, frontmatter, HTML, and code-metadata construct
- reject removed, reordered, duplicated, or newly introduced unsafe constructs with precise diagnostics
- keep the last accepted Markdown authoritative after rejection

## Verification

- [x] `bunx vitest run packages/cli/src/rich-preservation.test.ts` (9 tests)
- [x] `bunx vitest run packages/cli/src` (45 tests)
- [x] `bun run typecheck`
- [x] `bun run --cwd packages/cli build`
- [x] `bun run test:studio:browser -- --project=chromium`
- [x] `bunx changeset status`
- [x] `git diff --check`
- [x] Added a Changeset for the consumer-visible CLI fix
- [x] Documentation remains accurate; diagnostics become more precise without changing the documented surface
- [x] Existing coverage was not weakened or skipped

## Visual evidence

Not applicable — this hardens source preservation and diagnostics without changing Studio presentation.