### PR TITLE
fix(studio): keep table controls compact

### DIFF
--- a/.changeset/wide-studios-flow.md
+++ b/.changeset/wide-studios-flow.md
@@ -1,0 +1,5 @@
+---
+"@scribe-sdk/cli": patch
+---
+
+Keep Scribe Studio's Rich Text table controls compact without stealing space from article content. One- to three-column tables now fit the editor pane, while wider tables scroll within it and preserve GFM column alignment.

--- a/packages/cli/src/studio-ui.ts
+++ b/packages/cli/src/studio-ui.ts
@@ -663,11 +663,14 @@ svg { inline-size: 1rem; block-size: 1rem; stroke-width: 1.8; }
 .rich-content code { padding:.12em .3em; border:1px solid var(--studio-border); border-radius:.28rem; color:#ddffc0; background:var(--studio-control); font:.86em/1.4 var(--studio-mono); }
 .rich-content blockquote { margin:1.5rem 0; padding:.1rem 0 .1rem 1rem; border-inline-start:2px solid var(--studio-acid); color:#c4c4bd; }
 .rich-content table { inline-size:100%; margin-block:1.8rem; border:1px solid #3a3a37; border-collapse:separate; border-spacing:0; border-radius:.5rem; overflow:hidden; font-family:var(--studio-font); font-size:.88rem; }
-.rich-content th,.rich-content td { padding:.72rem .85rem; border:0; border-block-end:1px solid #343432; border-inline-end:1px solid #343432; text-align:start; vertical-align:top; }
-.rich-content th:last-child,.rich-content td:last-child { border-inline-end:0; }
-.rich-content tr:last-child td { border-block-end:0; }
-.rich-content th { color:var(--studio-text); background:#20201f; font-size:.72rem; text-transform:uppercase; letter-spacing:.055em; }
-.rich-content td { color:#d0d0ca; background:#121212; }
+.rich-content table[class*="_tableEditor"]:has(> colgroup > col:nth-child(6)) { min-inline-size:42rem; }
+.rich-content table[class*="_tableEditor"] > colgroup > col:first-child,.rich-content table[class*="_tableEditor"] > colgroup > col:last-child { inline-size:2rem; }
+.rich-content table[class*="_tableEditor"] > tbody > tr > :is(th,td):not([data-tool-cell]):not([class*="_toolCell"]) { padding:.72rem .85rem; border:0; border-block-end:1px solid #343432; border-inline-end:1px solid #343432; vertical-align:top; }
+.rich-content table[class*="_tableEditor"] > tbody > tr:last-child > :is(th,td):not([data-tool-cell]):not([class*="_toolCell"]) { border-block-end:0; }
+.rich-content table[class*="_tableEditor"] > :is(thead,tfoot) > tr > th,.rich-content table[class*="_tableEditor"] > tbody > tr > [data-tool-cell],.rich-content table[class*="_tableEditor"] > tbody > tr > [class*="_toolCell"] { padding:0; border:0; color:var(--studio-muted); background:#0d0d0d; }
+.rich-content table[class*="_tableEditor"] > thead > tr > :is(:first-child,:last-child),.rich-content table[class*="_tableEditor"] > tfoot > tr > :is(:first-child,:last-child),.rich-content table[class*="_tableEditor"] > tbody > tr > [class*="_toolCell"],.rich-content table[class*="_tableEditor"] > tbody > tr:first-child > [data-tool-cell]:last-child { inline-size:2rem; min-inline-size:2rem; max-inline-size:2rem; }
+.rich-content table[class*="_tableEditor"] > tbody > tr > th:not([data-tool-cell]):not([class*="_toolCell"]) { color:var(--studio-text); background:#20201f; font-size:.72rem; text-transform:uppercase; letter-spacing:.055em; }
+.rich-content table[class*="_tableEditor"] > tbody > tr > td:not([data-tool-cell]):not([class*="_toolCell"]) { color:#d0d0ca; background:#121212; }
 .rich-content img { display:block; max-inline-size:100%; block-size:auto; margin:1.5rem auto; border:1px solid var(--studio-border); border-radius:.45rem; }
 .protected-island { display:grid; grid-template-columns:auto minmax(0,1fr) auto; align-items:center; gap:.8rem; margin-block:1rem; padding:.8rem; border:1px dashed #56632e; border-radius:.52rem; color:var(--studio-muted); background:#10130b; font-family:var(--studio-font); }
 .protected-island__icon { display:grid; place-items:center; inline-size:2rem; block-size:2rem; border-radius:.38rem; color:#111; background:var(--studio-acid); }

--- a/tests/studio-browser/studio.spec.ts
+++ b/tests/studio-browser/studio.spec.ts
@@ -1,16 +1,39 @@
 import { expect, test } from "@playwright/test";
-import { readFile, writeFile } from "node:fs/promises";
+import type { Locator, Page } from "@playwright/test";
+import { readFile, rename, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
 const fixturePath = resolve("tests/fixtures/studio-article.mdx");
 let originalFixture = "";
+
+async function replaceFixture(source: string) {
+  const temporaryPath = `${fixturePath}.studio-test-${process.pid}`;
+  await writeFile(temporaryPath, source, "utf8");
+  await rename(temporaryPath, fixturePath);
+}
+
+async function captureTable(page: Page, table: Locator, path: string) {
+  await table.evaluate((element) => element.scrollIntoView({ block: "center", inline: "start" }));
+  const tableBox = await table.boundingBox();
+  const scrollerBox = await page.locator(".rich-editor-scroll").boundingBox();
+  if (!tableBox || !scrollerBox) throw new Error("Could not capture the Rich Text table.");
+  await page.screenshot({
+    path,
+    clip: {
+      x: Math.max(tableBox.x, scrollerBox.x),
+      y: tableBox.y,
+      width: Math.min(tableBox.width, scrollerBox.width),
+      height: tableBox.height
+    }
+  });
+}
 
 test.beforeAll(async () => {
   originalFixture = await readFile(fixturePath, "utf8");
 });
 
 test.afterAll(async () => {
-  if (originalFixture) await writeFile(fixturePath, originalFixture, "utf8");
+  if (originalFixture) await replaceFixture(originalFixture);
 });
 
 test("keeps Markdown canonical while constrained Rich Text edits update the mirror and production preview", async ({ page }, testInfo) => {
@@ -67,7 +90,26 @@ test("keeps Markdown canonical while constrained Rich Text edits update the mirr
   await expect(preview.locator("h1#recovered-draft")).toBeVisible();
   await expect(page.locator("#status-text")).toHaveText("Unsaved draft");
 
-  const richSource = "# Recovered draft\n\nEditable paragraph.\n\n<Callout variant=\"note\">Protected note.</Callout>\n";
+  const richSource = [
+    "# Recovered draft",
+    "",
+    "Editable paragraph.",
+    "",
+    "| Value |",
+    "| --- |",
+    "| one-column content |",
+    "",
+    "| Left | Center | Right |",
+    "| :--- | :---: | ---: |",
+    "| alpha | beta | gamma |",
+    "",
+    "| State | Direction | Payload | Retry | Notes |",
+    "| --- | --- | --- | --- | --- |",
+    "| choked | inbound | piece request | exponential | long-lived peer state |",
+    "",
+    '<Callout variant="note">Protected note.</Callout>',
+    ""
+  ].join("\n");
   await source.fill(richSource);
   await expect.poll(async () => page.evaluate(async () => (await fetch("/__scribe/api/document")).json().then((value) => value.source))).toBe(richSource);
   const beforeNoopSwitch = await page.evaluate(async () => (await fetch("/__scribe/api/document")).json());
@@ -87,12 +129,63 @@ test("keeps Markdown canonical while constrained Rich Text edits update the mirr
   await expect(page.getByText("Protected source", { exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Edit protected source in Markdown" })).toBeVisible();
   await expect(page.getByTestId("markdown-mirror")).toContainText("Editable paragraph.");
+  await page.setViewportSize({ width: 1100, height: 760 });
+  const editorTables = page.locator('.rich-content table[class*="_tableEditor"]');
+  await expect(editorTables).toHaveCount(3);
+  const tableMetrics = await editorTables.evaluateAll((tables) => tables.map((table) => {
+    const scroller = table.closest(".rich-editor-scroll");
+    const cols = [...table.querySelectorAll(":scope > colgroup > col")];
+    const dataCells = [...table.querySelectorAll(":scope > tbody > tr:first-child > :is(th,td):not([data-tool-cell]):not([class*='_toolCell'])")];
+    const columnControl = table.querySelector(":scope > thead > tr > [data-tool-cell]:not(:last-child)");
+    const rowControl = table.querySelector(":scope > tbody > tr:first-child > [class*='_toolCell']");
+    const addColumnControl = table.querySelector(":scope > tbody > tr:first-child > [data-tool-cell]:last-child");
+    const dataCell = dataCells[0];
+    if (!(scroller instanceof HTMLElement) || !(table instanceof HTMLElement) || !(columnControl instanceof HTMLElement) || !(rowControl instanceof HTMLElement) || !(addColumnControl instanceof HTMLElement) || !(dataCell instanceof HTMLElement)) {
+      throw new Error("Missing expected MDXEditor table structure.");
+    }
+    const tableWidth = table.getBoundingClientRect().width;
+    const dataWidth = dataCells.reduce((total, cell) => total + cell.getBoundingClientRect().width, 0);
+    const style = getComputedStyle(dataCell);
+    return {
+      dataColumns: cols.length - 2,
+      tableWidth,
+      scrollerWidth: scroller.getBoundingClientRect().width,
+      dataShare: dataWidth / tableWidth,
+      columnControlWidth: columnControl.getBoundingClientRect().width,
+      rowControlWidth: rowControl.getBoundingClientRect().width,
+      addColumnControlWidth: addColumnControl.getBoundingClientRect().width,
+      paddingInline: Number.parseFloat(style.paddingInlineStart),
+      borderStyle: style.borderInlineEndStyle,
+      borderWidth: Number.parseFloat(style.borderInlineEndWidth)
+    };
+  }));
+  expect(tableMetrics.map(({ dataColumns }) => dataColumns)).toEqual([1, 3, 5]);
+  for (const metric of tableMetrics.slice(0, 2)) {
+    expect(metric.tableWidth).toBeLessThanOrEqual(metric.scrollerWidth + 1);
+    expect(metric.dataShare).toBeGreaterThanOrEqual(0.75);
+    expect(metric.columnControlWidth).toBeGreaterThan(40);
+  }
+  const wideTable = tableMetrics.at(2);
+  if (!wideTable) throw new Error("Missing wide Rich Text table metrics.");
+  expect(wideTable.tableWidth).toBeGreaterThan(wideTable.scrollerWidth);
+  for (const metric of tableMetrics) {
+    expect(metric.rowControlWidth).toBeLessThanOrEqual(40);
+    expect(metric.addColumnControlWidth).toBeLessThanOrEqual(40);
+    expect(metric.paddingInline).toBeGreaterThanOrEqual(10);
+    expect(metric.borderStyle).toBe("solid");
+    expect(metric.borderWidth).toBeGreaterThanOrEqual(1);
+  }
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true);
+  await captureTable(page, editorTables.nth(0), testInfo.outputPath("studio-table-one.png"));
+  await captureTable(page, editorTables.nth(1), testInfo.outputPath("studio-table-three.png"));
+  await captureTable(page, editorTables.nth(2), testInfo.outputPath("studio-table-wide.png"));
   await page.screenshot({ path: testInfo.outputPath("studio-rich-text.png"), fullPage: true });
 
   const richParagraph = page.locator(".rich-content p").filter({ hasText: "Editable paragraph." });
   await richParagraph.click({ clickCount: 3 });
   await page.keyboard.type("Visually edited paragraph.");
   await expect(page.getByTestId("markdown-mirror")).toContainText("Visually edited paragraph.");
+  await expect(page.getByTestId("markdown-mirror")).toContainText(/\| :--+ \| :--+: \| --+: \|/u);
   await expect(page.locator("#status-text")).toHaveText("Unsaved draft");
 
   await page.getByRole("tab", { name: "Preview tab" }).click();
@@ -124,7 +217,7 @@ test("keeps Markdown canonical while constrained Rich Text edits update the mirr
   await expect(page.getByRole("alert").filter({ hasText: "Source changed outside Studio" })).toHaveCount(0);
   await expect(page.locator("#status-text")).toHaveText("Ready");
 
-  await writeFile(fixturePath, originalFixture, "utf8");
+  await replaceFixture(originalFixture);
   await expect(source).toHaveValue(/Peer state transitions/u);
 
   expect(issues).toEqual([]);


### PR DESCRIPTION
## Linear

Fixes AET-17

## Summary

- target MDXEditor utility columns without shrinking content-column controls
- keep one- to three-column GFM tables within the Rich Text pane and scroll wider tables internally
- preserve GFM alignment semantics and add one-, three-, and five-column layout regressions

## Verification

- [x] Focused tests pass
- [x] Type checking passes
- [x] Meaningful consumer-facing changes include a Changeset
- [x] No documentation change is needed
- [x] Existing coverage was not weakened or skipped

## Visual evidence

Generated and manually inspected `studio-table-one.png`, `studio-table-three.png`, and `studio-table-wide.png` from the focused Chromium Studio flow. One- and three-column tables allocate the pane to content; the five-column table remains contained with internal horizontal overflow.