### PR TITLE
feat(cli): promote scribe as the primary command

### DIFF
--- a/.changeset/clear-scribes-command.md
+++ b/.changeset/clear-scribes-command.md
@@ -1,0 +1,5 @@
+---
+"@scribe-sdk/cli": patch
+---
+
+Promote `scribe` as the primary command while retaining `scb` as a silent prerelease compatibility alias. Add focused subcommand help, typo suggestions, project-relative diagnostics, structured initialization and validation output, and deterministic ANSI-free behavior for captured output and `NO_COLOR` environments.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Scribe is not a hosted blogging platform, CMS, website builder, rich-text editor
 | `@scribe-sdk/react` | Publication boundary, component map, and editorial primitives | package root |
 | `@scribe-sdk/styles` | Scoped publishing mechanics and optional editorial presentation | `/foundation.css`, `/default.css`, `/tailwind.css` |
 | `@scribe-sdk/mdx` | Shared compile-time MDX configuration and validation | package root, `/next`, `/next-remote`, `/remark`, `/rehype` |
-| `@scribe-sdk/cli` | Validation, deliberate setup, and the local authoring Studio | `scb` binary |
+| `@scribe-sdk/cli` | Validation, deliberate setup, and the local authoring Studio | `scribe` binary |
 
 Each installed package includes the same canonical `SKILL.md`. Agents can discover it at `node_modules/@scribe-sdk/<package>/SKILL.md`; the repository source of truth is [`SKILL.md`](./SKILL.md).
 
@@ -35,31 +35,35 @@ npm install @scribe-sdk/react@alpha @scribe-sdk/styles@alpha @scribe-sdk/mdx@alp
 npm install --save-dev @scribe-sdk/cli@alpha
 ```
 
+Project-local CLI installation is recommended so every contributor uses the same prerelease. A user-level CLI is also supported through `bun add --global @scribe-sdk/cli@alpha` or `npm install --global @scribe-sdk/cli@alpha`; the project still owns its runtime Scribe dependencies.
+
 Package installation is inert: it does not edit source files, run project detection, or make network calls beyond normal package-manager behavior. Inspect a proposed integration explicitly:
 
 ```bash
-bunx scb init --dry-run
+bunx scribe init --dry-run
 ```
 
 With npm, run the same locally installed binary through `npx`:
 
 ```bash
-npx scb init --dry-run
+npx scribe init --dry-run
 ```
 
 ### CLI reference
 
-Run CLI commands through `bunx scb` or `npx scb` after installing `@scribe-sdk/cli` locally. The examples below use `scb` to show the command surface without repeating both runners.
+Run CLI commands through `bunx scribe` or `npx scribe` after installing `@scribe-sdk/cli` locally. The examples below use `scribe` to show the command surface without repeating both runners.
+
+`scribe` is the primary executable. The prerelease-only `scb` compatibility alias remains available with identical behavior for existing alpha users; new integrations should use `scribe`.
 
 | Command | Purpose |
 | --- | --- |
-| `scb init [--dry-run] [--mode <mode>] [--yes]` | Inspect and deliberately initialize Scribe in the current React project; mode is `foundation`, `default`, or `tailwind` |
-| `scb validate <article.mdx> [--strict]` | Compile and validate one article without executing the complete host application |
-| `scb studio <article> [--mode <mode>] [--host-css <file>] [--port <number>] [--no-open]` | Open the local, source-authoritative Markdown/MDX Studio; mode is `foundation`, `default`, or `tailwind` |
-| `scb --help` | Show the installed CLI command surface |
-| `scb --version` | Print the installed Scribe version |
+| `scribe init [--dry-run] [--mode <mode>] [--yes]` | Inspect and deliberately initialize Scribe in the current React project; mode is `foundation`, `default`, or `tailwind` |
+| `scribe validate <article.mdx> [--strict]` | Compile and validate one article without executing the complete host application |
+| `scribe studio <article> [--mode <mode>] [--host-css <file>] [--port <number>] [--no-open]` | Open the local, source-authoritative Markdown/MDX Studio; mode is `foundation`, `default`, or `tailwind` |
+| `scribe --help` | Show the installed CLI command surface |
+| `scribe --version` | Print the installed Scribe version |
 
-Use `scb init --help` or `scb studio --help` for command-specific option summaries. CLI exit codes are consistent: `0` means success, `1` means execution or article-compilation failure, and `2` means invalid usage or unresolved initialization configuration.
+Use `scribe init --help`, `scribe validate --help`, or `scribe studio --help` for focused option summaries and examples. CLI exit codes are consistent: `0` means success, `1` means execution or article-compilation failure, and `2` means invalid usage or unresolved initialization configuration.
 
 ## Choose a style mode
 
@@ -96,15 +100,15 @@ Scribe ships no fonts and does not clone Tailwind Typography. In Tailwind mode, 
 Run initialization deliberately from the host project's root after installation:
 
 ```bash
-bunx scb init --dry-run
-bunx scb init
+bunx scribe init --dry-run
+bunx scribe init
 ```
 
 With npm:
 
 ```bash
-npx scb init --dry-run
-npx scb init
+npx scribe init --dry-run
+npx scribe init
 ```
 
 `init` inspects React, Next.js or Vite, Tailwind v3/v4, Typography and `.prose`, existing MDX integrations and plugins, syntax highlighters, global CSS, component maps, and current Scribe wiring. It recommends `foundation`, `default`, or `tailwind`, reports every proposed command and file edit, and asks before mutation. Use `--mode foundation|default|tailwind` to override the recommendation or `--yes` for a reviewed non-interactive plan.
@@ -322,7 +326,7 @@ Supported metadata is explicit:
 | additions | `add="4-6"` | Marks added lines |
 | removals | `remove="2"` | Marks removed lines |
 
-Ranges are one-based, comma-separated, and inclusive. Unknown or malformed fields fail compilation. Unsupported languages warn and fall back to plaintext by default. Enable strict behavior with `createScribeMdxOptions({ strict: true })`, `createScribeNextMdxOptions({ strict: true })`, or `scb validate article.mdx --strict`.
+Ranges are one-based, comma-separated, and inclusive. Unknown or malformed fields fail compilation. Unsupported languages warn and fall back to plaintext by default. Enable strict behavior with `createScribeMdxOptions({ strict: true })`, `createScribeNextMdxOptions({ strict: true })`, or `scribe validate article.mdx --strict`.
 
 Inline backticks remain visually distinct from framed code blocks.
 
@@ -391,18 +395,18 @@ Reduced-motion preferences disable nonessential transitions. Print styles remove
 Open a source-authoritative local workspace for one Markdown or MDX file:
 
 ```bash
-bunx scb studio ./content/article.mdx
-bunx scb studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
+bunx scribe studio ./content/article.mdx
+bunx scribe studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
 ```
 
 With npm:
 
 ```bash
-npx scb studio ./content/article.mdx
-npx scb studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
+npx scribe studio ./content/article.mdx
+npx scribe studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
 ```
 
-Studio detects the project style mode using the same rules as `scb init`; pass `--mode` only to override that result deliberately. An ambiguous project exits with guidance instead of silently choosing a visual preset. Port `4317` remains the default.
+Studio detects the project style mode using the same rules as `scribe init`; pass `--mode` only to override that result deliberately. An ambiguous project exits with guidance instead of silently choosing a visual preset. Port `4317` remains the default.
 
 Studio has exactly two authoring modes. Markdown mode keeps the source editable beside the production renderer and has no formatting toolbar. Rich Text mode is a constrained visual helper for ordinary Markdown; it provides a minimal toolbar, writes accepted edits back to the canonical Markdown draft, and shows a read-only Markdown mirror by default. Its secondary pane can switch to the same production renderer. Unsupported MDX, frontmatter, HTML, JSX, expressions, and metadata-bearing code fences remain byte-identical protected blocks with an **Edit in Markdown** action. Rich Text may refuse to edit a construct; it never pretends to support one and silently rewrites the source.
 
@@ -419,34 +423,34 @@ Use `--port 4317` to select a port and `--no-open` for headless workflows. Stop 
 Validate one article through the production compiler:
 
 ```bash
-bunx scb validate ./content/article.mdx
-bunx scb validate ./content/article.mdx --strict
+bunx scribe validate ./content/article.mdx
+bunx scribe validate ./content/article.mdx --strict
 ```
 
 With npm:
 
 ```bash
-npx scb validate ./content/article.mdx
-npx scb validate ./content/article.mdx --strict
+npx scribe validate ./content/article.mdx
+npx scribe validate ./content/article.mdx --strict
 ```
 
-`scb validate` checks MDX syntax, Scribe code metadata, supported static component metadata, compile-time highlighting, and article-level diagnostics. It does not execute or validate the complete consumer application.
+`scribe validate` checks MDX syntax, Scribe code metadata, supported static component metadata, compile-time highlighting, and article-level diagnostics. It does not execute or validate the complete consumer application.
 
 - Exit `0`: validation succeeded; warnings may have been printed.
 - Exit `1`: article compilation or strict validation failed.
 - Exit `2`: command usage was invalid.
 
-Diagnostics include the file, position when available, severity, stable code, and remediation. Unsupported languages use warning `SCB1003` and plaintext fallback unless strict mode is enabled. Run `scb --help` for the complete supported CLI surface.
+Diagnostics include the file, position when available, severity, stable code, and remediation. Unsupported languages use warning `SCB1003` and plaintext fallback unless strict mode is enabled. Run `scribe --help` for the complete supported CLI surface.
 
 If rendering differs between the Vite and Next builds, confirm that both use the matching `@scribe-sdk/mdx` version and the shared helper. If a table is not scrollable, confirm that the stylesheet is imported and the article renders beneath `.scribe`. Do not add host CSS solely to conceal a Scribe defect; reduce the case and report it at <https://github.com/aetosdios27/scribe/issues>.
 
 ## Migrating from `0.1.0-alpha.2`
 
 - Existing `default.css` imports remain supported and retain the complete editorial preset.
-- Established sites that already own article typography should switch to `foundation.css` after reviewing `scb init --dry-run` and before/after computed styles.
+- Established sites that already own article typography should switch to `foundation.css` after reviewing `scribe init --dry-run` and before/after computed styles.
 - Tailwind Typography sites should use `tailwind.css` and keep their `.prose` wrapper.
 - `next-mdx-remote/rsc` integrations should replace loader-shaped configuration with `createScribeRemoteMdxOptions()` from `@scribe-sdk/mdx/next-remote`.
-- Installation performs no migration. `scb init` reports and confirms any safe edits; existing plugins and highlighters remain untouched unless the owner changes them explicitly.
+- Installation performs no migration. `scribe init` reports and confirms any safe edits; existing plugins and highlighters remain untouched unless the owner changes them explicitly.
 
 ## Responsibility boundary
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -143,7 +143,7 @@ After versioning, run every gate from the repository root:
 - [ ] Inspect tarball contents, manifests, declarations, README, SKILL, LICENSE, and repository-only exclusions: `bun run release:inspect`
 - [ ] Install the packed tarballs and smoke-test portable CLI paths: `bun run test:portability`
 - [ ] Run isolated packed Vite and Next consumers with Bun and npm: `bun run release:consumers`
-- [ ] Check the packaged CLI version and help from the packed consumer: `bunx scb --version` and `bunx scb --help`
+- [ ] Check the packaged CLI version and help from the packed consumer: `bunx scribe --version` and `bunx scribe --help`
 - [ ] Validate valid and invalid article fixtures through the packaged CLI
 - [ ] Run required portable browser behavior: `bun run test:browser:chromium` and `bun run test:browser:firefox`
 - [ ] Run the Studio edit, save, invalid-source, and recovery flow: `bun run test:studio:browser`
@@ -191,9 +191,9 @@ In a fresh consumer, install only the published alpha packages:
 ```bash
 bun add @scribe-sdk/react@alpha @scribe-sdk/styles@alpha @scribe-sdk/mdx@alpha
 bun add --dev @scribe-sdk/cli@alpha
-bunx scb --version
-bunx scb --help
-bunx scb validate path/to/article.mdx
+bunx scribe --version
+bunx scribe --help
+bunx scribe validate path/to/article.mdx
 ```
 
 Run that consumer’s strict typecheck and production build. Confirm each installed `node_modules/@scribe-sdk/*/package.json` reports the same version before creating any Git tag or GitHub release.

--- a/SKILL.md
+++ b/SKILL.md
@@ -36,10 +36,10 @@ Expected packages are `@scribe-sdk/react`, `@scribe-sdk/styles`, `@scribe-sdk/md
 Start with the deliberate detector:
 
 ```bash
-bunx scb init --dry-run
+bunx scribe init --dry-run
 ```
 
-Review the detected stack, recommended mode, touched files, commands, ambiguities, and existing highlighter warnings. Run `bunx scb init` only after the plan is safe. Installation itself is inert.
+Review the detected stack, recommended mode, touched files, commands, ambiguities, and existing highlighter warnings. Run `bunx scribe init` only after the plan is safe. Installation itself is inert.
 
 Choose exactly one style mode:
 
@@ -177,11 +177,11 @@ Scribe supplies color-scheme-aware styles. The host owns the runtime light/dark 
 Run:
 
 ```bash
-bunx scb validate path/to/article.mdx
-bunx scb validate path/to/article.mdx --strict
+bunx scribe validate path/to/article.mdx
+bunx scribe validate path/to/article.mdx --strict
 ```
 
-With npm, use `npx scb validate path/to/article.mdx`.
+With npm, use `npx scribe validate path/to/article.mdx`.
 
 Interpret exit codes as `0` success, `1` article validation failure, and `2` invalid CLI usage. Warnings do not fail unless strict mode requires it. Diagnostics should name the file, position when available, severity, stable code, and remediation.
 
@@ -192,10 +192,10 @@ For an established site, compare computed body font, body size, line height, par
 Use Studio for a source-authoritative local editing loop when helpful:
 
 ```bash
-bunx scb studio path/to/article.mdx --mode foundation
+bunx scribe studio path/to/article.mdx --mode foundation
 ```
 
-Studio detects the project style mode with the same rules as `scb init`; use `--mode` only as a deliberate override. Markdown mode edits source beside the production renderer. Rich Text mode is a constrained visual helper whose accepted edits serialize to the canonical Markdown draft; its Markdown mirror is read-only, and unsupported MDX remains a byte-identical protected block that must be edited in Markdown mode. Studio saves explicitly to the displayed article path, warns before closing with unwritten changes, detects external conflicts, and writes atomically. Frontmatter supplies a generated Banner when it includes a title and no explicit Banner exists. Absolute image paths resolve from the project `public` directory, and missing assets remain visible in the preview. Studio is local-only and not a WYSIWYG editor, CMS, or page builder. Use `--host-css` only for one explicit local CSS file and account for framework preprocessing limitations.
+Studio detects the project style mode with the same rules as `scribe init`; use `--mode` only as a deliberate override. Markdown mode edits source beside the production renderer. Rich Text mode is a constrained visual helper whose accepted edits serialize to the canonical Markdown draft; its Markdown mirror is read-only, and unsupported MDX remains a byte-identical protected block that must be edited in Markdown mode. Studio saves explicitly to the displayed article path, warns before closing with unwritten changes, detects external conflicts, and writes atomically. Frontmatter supplies a generated Banner when it includes a title and no explicit Banner exists. Absolute image paths resolve from the project `public` directory, and missing assets remain visible in the preview. Studio is local-only and not a WYSIWYG editor, CMS, or page builder. Use `--host-css` only for one explicit local CSS file and account for framework preprocessing limitations.
 
 ## Diagnose the boundary
 
@@ -218,5 +218,5 @@ Reduce defects to ordinary semantic content before adding CSS. Do not introduce 
 - Confirm Shiki output is static and browser bundles contain no highlighter runtime.
 - Confirm copy is the only article behavior requiring hydration.
 - Confirm host fonts, colors, radius, and theme behavior remain native.
-- Run `bunx scb validate`, strict TypeScript, and the host production build.
+- Run `bunx scribe validate`, strict TypeScript, and the host production build.
 - Visually inspect desktop and mobile output before declaring success.

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
       "name": "@scribe-sdk/cli",
       "version": "0.1.0-alpha.5",
       "bin": {
+        "scribe": "./dist/index.mjs",
         "scb": "./dist/index.mjs",
       },
       "dependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@types/node": "22.20.1",
         "@types/react": "19.2.17",
         "@typescript/native": "npm:typescript@7.0.2",
+        "cross-spawn": "7.0.6",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "tsdown": "0.22.7",

--- a/bun.lock
+++ b/bun.lock
@@ -178,6 +178,7 @@
   },
   "overrides": {
     "@types/mdx": "2.0.14",
+    "js-yaml": "4.3.0",
     "postcss": "8.5.19",
   },
   "packages": {
@@ -1025,8 +1026,6 @@
 
     "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
-    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
-
     "estree-util-attach-comments": ["estree-util-attach-comments@3.0.0", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw=="],
 
     "estree-util-build-jsx": ["estree-util-build-jsx@3.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-walker": "^3.0.0" } }, "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ=="],
@@ -1139,7 +1138,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
@@ -1505,8 +1504,6 @@
 
     "spawndamnit": ["spawndamnit@3.0.1", "", { "dependencies": { "cross-spawn": "^7.0.5", "signal-exit": "^4.0.1" } }, "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg=="],
 
-    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
-
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
@@ -1629,8 +1626,6 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@changesets/parse/js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
-
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
@@ -1685,8 +1680,6 @@
 
     "read-cache/pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
-    "read-yaml-file/js-yaml": ["js-yaml@3.15.0", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog=="],
-
     "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "tailwindcss/postcss-selector-parser": ["postcss-selector-parser@6.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ=="],
@@ -1694,7 +1687,5 @@
     "unconfig-core/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
     "vitest/vite": ["vite@8.1.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.17", "rolldown": "~1.1.5", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw=="],
-
-    "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "overrides": {
     "@types/mdx": "2.0.14",
+    "js-yaml": "4.3.0",
     "postcss": "8.5.19"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/node": "22.20.1",
     "@types/react": "19.2.17",
     "@typescript/native": "npm:typescript@7.0.2",
+    "cross-spawn": "7.0.6",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "tsdown": "0.22.7",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,7 +15,7 @@ Scribe is not a hosted blogging platform, CMS, website builder, rich-text editor
 | `@scribe-sdk/react` | Publication boundary, component map, and editorial primitives | package root |
 | `@scribe-sdk/styles` | Scoped publishing mechanics and optional editorial presentation | `/foundation.css`, `/default.css`, `/tailwind.css` |
 | `@scribe-sdk/mdx` | Shared compile-time MDX configuration and validation | package root, `/next`, `/next-remote`, `/remark`, `/rehype` |
-| `@scribe-sdk/cli` | Validation, deliberate setup, and the local authoring Studio | `scb` binary |
+| `@scribe-sdk/cli` | Validation, deliberate setup, and the local authoring Studio | `scribe` binary |
 
 Each installed package includes the same canonical `SKILL.md`. Agents can discover it at `node_modules/@scribe-sdk/<package>/SKILL.md`; the repository source of truth is [`SKILL.md`](./SKILL.md).
 
@@ -35,31 +35,35 @@ npm install @scribe-sdk/react@alpha @scribe-sdk/styles@alpha @scribe-sdk/mdx@alp
 npm install --save-dev @scribe-sdk/cli@alpha
 ```
 
+Project-local CLI installation is recommended so every contributor uses the same prerelease. A user-level CLI is also supported through `bun add --global @scribe-sdk/cli@alpha` or `npm install --global @scribe-sdk/cli@alpha`; the project still owns its runtime Scribe dependencies.
+
 Package installation is inert: it does not edit source files, run project detection, or make network calls beyond normal package-manager behavior. Inspect a proposed integration explicitly:
 
 ```bash
-bunx scb init --dry-run
+bunx scribe init --dry-run
 ```
 
 With npm, run the same locally installed binary through `npx`:
 
 ```bash
-npx scb init --dry-run
+npx scribe init --dry-run
 ```
 
 ### CLI reference
 
-Run CLI commands through `bunx scb` or `npx scb` after installing `@scribe-sdk/cli` locally. The examples below use `scb` to show the command surface without repeating both runners.
+Run CLI commands through `bunx scribe` or `npx scribe` after installing `@scribe-sdk/cli` locally. The examples below use `scribe` to show the command surface without repeating both runners.
+
+`scribe` is the primary executable. The prerelease-only `scb` compatibility alias remains available with identical behavior for existing alpha users; new integrations should use `scribe`.
 
 | Command | Purpose |
 | --- | --- |
-| `scb init [--dry-run] [--mode <mode>] [--yes]` | Inspect and deliberately initialize Scribe in the current React project; mode is `foundation`, `default`, or `tailwind` |
-| `scb validate <article.mdx> [--strict]` | Compile and validate one article without executing the complete host application |
-| `scb studio <article> [--mode <mode>] [--host-css <file>] [--port <number>] [--no-open]` | Open the local, source-authoritative Markdown/MDX Studio; mode is `foundation`, `default`, or `tailwind` |
-| `scb --help` | Show the installed CLI command surface |
-| `scb --version` | Print the installed Scribe version |
+| `scribe init [--dry-run] [--mode <mode>] [--yes]` | Inspect and deliberately initialize Scribe in the current React project; mode is `foundation`, `default`, or `tailwind` |
+| `scribe validate <article.mdx> [--strict]` | Compile and validate one article without executing the complete host application |
+| `scribe studio <article> [--mode <mode>] [--host-css <file>] [--port <number>] [--no-open]` | Open the local, source-authoritative Markdown/MDX Studio; mode is `foundation`, `default`, or `tailwind` |
+| `scribe --help` | Show the installed CLI command surface |
+| `scribe --version` | Print the installed Scribe version |
 
-Use `scb init --help` or `scb studio --help` for command-specific option summaries. CLI exit codes are consistent: `0` means success, `1` means execution or article-compilation failure, and `2` means invalid usage or unresolved initialization configuration.
+Use `scribe init --help`, `scribe validate --help`, or `scribe studio --help` for focused option summaries and examples. CLI exit codes are consistent: `0` means success, `1` means execution or article-compilation failure, and `2` means invalid usage or unresolved initialization configuration.
 
 ## Choose a style mode
 
@@ -96,15 +100,15 @@ Scribe ships no fonts and does not clone Tailwind Typography. In Tailwind mode, 
 Run initialization deliberately from the host project's root after installation:
 
 ```bash
-bunx scb init --dry-run
-bunx scb init
+bunx scribe init --dry-run
+bunx scribe init
 ```
 
 With npm:
 
 ```bash
-npx scb init --dry-run
-npx scb init
+npx scribe init --dry-run
+npx scribe init
 ```
 
 `init` inspects React, Next.js or Vite, Tailwind v3/v4, Typography and `.prose`, existing MDX integrations and plugins, syntax highlighters, global CSS, component maps, and current Scribe wiring. It recommends `foundation`, `default`, or `tailwind`, reports every proposed command and file edit, and asks before mutation. Use `--mode foundation|default|tailwind` to override the recommendation or `--yes` for a reviewed non-interactive plan.
@@ -322,7 +326,7 @@ Supported metadata is explicit:
 | additions | `add="4-6"` | Marks added lines |
 | removals | `remove="2"` | Marks removed lines |
 
-Ranges are one-based, comma-separated, and inclusive. Unknown or malformed fields fail compilation. Unsupported languages warn and fall back to plaintext by default. Enable strict behavior with `createScribeMdxOptions({ strict: true })`, `createScribeNextMdxOptions({ strict: true })`, or `scb validate article.mdx --strict`.
+Ranges are one-based, comma-separated, and inclusive. Unknown or malformed fields fail compilation. Unsupported languages warn and fall back to plaintext by default. Enable strict behavior with `createScribeMdxOptions({ strict: true })`, `createScribeNextMdxOptions({ strict: true })`, or `scribe validate article.mdx --strict`.
 
 Inline backticks remain visually distinct from framed code blocks.
 
@@ -391,18 +395,18 @@ Reduced-motion preferences disable nonessential transitions. Print styles remove
 Open a source-authoritative local workspace for one Markdown or MDX file:
 
 ```bash
-bunx scb studio ./content/article.mdx
-bunx scb studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
+bunx scribe studio ./content/article.mdx
+bunx scribe studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
 ```
 
 With npm:
 
 ```bash
-npx scb studio ./content/article.mdx
-npx scb studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
+npx scribe studio ./content/article.mdx
+npx scribe studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
 ```
 
-Studio detects the project style mode using the same rules as `scb init`; pass `--mode` only to override that result deliberately. An ambiguous project exits with guidance instead of silently choosing a visual preset. Port `4317` remains the default.
+Studio detects the project style mode using the same rules as `scribe init`; pass `--mode` only to override that result deliberately. An ambiguous project exits with guidance instead of silently choosing a visual preset. Port `4317` remains the default.
 
 Studio has exactly two authoring modes. Markdown mode keeps the source editable beside the production renderer and has no formatting toolbar. Rich Text mode is a constrained visual helper for ordinary Markdown; it provides a minimal toolbar, writes accepted edits back to the canonical Markdown draft, and shows a read-only Markdown mirror by default. Its secondary pane can switch to the same production renderer. Unsupported MDX, frontmatter, HTML, JSX, expressions, and metadata-bearing code fences remain byte-identical protected blocks with an **Edit in Markdown** action. Rich Text may refuse to edit a construct; it never pretends to support one and silently rewrites the source.
 
@@ -419,34 +423,34 @@ Use `--port 4317` to select a port and `--no-open` for headless workflows. Stop 
 Validate one article through the production compiler:
 
 ```bash
-bunx scb validate ./content/article.mdx
-bunx scb validate ./content/article.mdx --strict
+bunx scribe validate ./content/article.mdx
+bunx scribe validate ./content/article.mdx --strict
 ```
 
 With npm:
 
 ```bash
-npx scb validate ./content/article.mdx
-npx scb validate ./content/article.mdx --strict
+npx scribe validate ./content/article.mdx
+npx scribe validate ./content/article.mdx --strict
 ```
 
-`scb validate` checks MDX syntax, Scribe code metadata, supported static component metadata, compile-time highlighting, and article-level diagnostics. It does not execute or validate the complete consumer application.
+`scribe validate` checks MDX syntax, Scribe code metadata, supported static component metadata, compile-time highlighting, and article-level diagnostics. It does not execute or validate the complete consumer application.
 
 - Exit `0`: validation succeeded; warnings may have been printed.
 - Exit `1`: article compilation or strict validation failed.
 - Exit `2`: command usage was invalid.
 
-Diagnostics include the file, position when available, severity, stable code, and remediation. Unsupported languages use warning `SCB1003` and plaintext fallback unless strict mode is enabled. Run `scb --help` for the complete supported CLI surface.
+Diagnostics include the file, position when available, severity, stable code, and remediation. Unsupported languages use warning `SCB1003` and plaintext fallback unless strict mode is enabled. Run `scribe --help` for the complete supported CLI surface.
 
 If rendering differs between the Vite and Next builds, confirm that both use the matching `@scribe-sdk/mdx` version and the shared helper. If a table is not scrollable, confirm that the stylesheet is imported and the article renders beneath `.scribe`. Do not add host CSS solely to conceal a Scribe defect; reduce the case and report it at <https://github.com/aetosdios27/scribe/issues>.
 
 ## Migrating from `0.1.0-alpha.2`
 
 - Existing `default.css` imports remain supported and retain the complete editorial preset.
-- Established sites that already own article typography should switch to `foundation.css` after reviewing `scb init --dry-run` and before/after computed styles.
+- Established sites that already own article typography should switch to `foundation.css` after reviewing `scribe init --dry-run` and before/after computed styles.
 - Tailwind Typography sites should use `tailwind.css` and keep their `.prose` wrapper.
 - `next-mdx-remote/rsc` integrations should replace loader-shaped configuration with `createScribeRemoteMdxOptions()` from `@scribe-sdk/mdx/next-remote`.
-- Installation performs no migration. `scb init` reports and confirms any safe edits; existing plugins and highlighters remain untouched unless the owner changes them explicitly.
+- Installation performs no migration. `scribe init` reports and confirms any safe edits; existing plugins and highlighters remain untouched unless the owner changes them explicitly.
 
 ## Responsibility boundary
 

--- a/packages/cli/SKILL.md
+++ b/packages/cli/SKILL.md
@@ -36,10 +36,10 @@ Expected packages are `@scribe-sdk/react`, `@scribe-sdk/styles`, `@scribe-sdk/md
 Start with the deliberate detector:
 
 ```bash
-bunx scb init --dry-run
+bunx scribe init --dry-run
 ```
 
-Review the detected stack, recommended mode, touched files, commands, ambiguities, and existing highlighter warnings. Run `bunx scb init` only after the plan is safe. Installation itself is inert.
+Review the detected stack, recommended mode, touched files, commands, ambiguities, and existing highlighter warnings. Run `bunx scribe init` only after the plan is safe. Installation itself is inert.
 
 Choose exactly one style mode:
 
@@ -177,11 +177,11 @@ Scribe supplies color-scheme-aware styles. The host owns the runtime light/dark 
 Run:
 
 ```bash
-bunx scb validate path/to/article.mdx
-bunx scb validate path/to/article.mdx --strict
+bunx scribe validate path/to/article.mdx
+bunx scribe validate path/to/article.mdx --strict
 ```
 
-With npm, use `npx scb validate path/to/article.mdx`.
+With npm, use `npx scribe validate path/to/article.mdx`.
 
 Interpret exit codes as `0` success, `1` article validation failure, and `2` invalid CLI usage. Warnings do not fail unless strict mode requires it. Diagnostics should name the file, position when available, severity, stable code, and remediation.
 
@@ -192,10 +192,10 @@ For an established site, compare computed body font, body size, line height, par
 Use Studio for a source-authoritative local editing loop when helpful:
 
 ```bash
-bunx scb studio path/to/article.mdx --mode foundation
+bunx scribe studio path/to/article.mdx --mode foundation
 ```
 
-Studio detects the project style mode with the same rules as `scb init`; use `--mode` only as a deliberate override. Markdown mode edits source beside the production renderer. Rich Text mode is a constrained visual helper whose accepted edits serialize to the canonical Markdown draft; its Markdown mirror is read-only, and unsupported MDX remains a byte-identical protected block that must be edited in Markdown mode. Studio saves explicitly to the displayed article path, warns before closing with unwritten changes, detects external conflicts, and writes atomically. Frontmatter supplies a generated Banner when it includes a title and no explicit Banner exists. Absolute image paths resolve from the project `public` directory, and missing assets remain visible in the preview. Studio is local-only and not a WYSIWYG editor, CMS, or page builder. Use `--host-css` only for one explicit local CSS file and account for framework preprocessing limitations.
+Studio detects the project style mode with the same rules as `scribe init`; use `--mode` only as a deliberate override. Markdown mode edits source beside the production renderer. Rich Text mode is a constrained visual helper whose accepted edits serialize to the canonical Markdown draft; its Markdown mirror is read-only, and unsupported MDX remains a byte-identical protected block that must be edited in Markdown mode. Studio saves explicitly to the displayed article path, warns before closing with unwritten changes, detects external conflicts, and writes atomically. Frontmatter supplies a generated Banner when it includes a title and no explicit Banner exists. Absolute image paths resolve from the project `public` directory, and missing assets remain visible in the preview. Studio is local-only and not a WYSIWYG editor, CMS, or page builder. Use `--host-css` only for one explicit local CSS file and account for framework preprocessing limitations.
 
 ## Diagnose the boundary
 
@@ -218,5 +218,5 @@ Reduce defects to ordinary semantic content before adding CSS. Do not introduce 
 - Confirm Shiki output is static and browser bundles contain no highlighter runtime.
 - Confirm copy is the only article behavior requiring hydration.
 - Confirm host fonts, colors, radius, and theme behavior remain native.
-- Run `bunx scb validate`, strict TypeScript, and the host production build.
+- Run `bunx scribe validate`, strict TypeScript, and the host production build.
 - Visually inspect desktop and mobile output before declaring success.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scribe-sdk/cli",
   "version": "0.1.0-alpha.5",
-  "description": "The scb command-line validator for Scribe MDX articles.",
+  "description": "The Scribe command-line interface for project setup, article validation, and local authoring.",
   "author": "aetosdios27",
   "license": "Apache-2.0",
   "type": "module",
@@ -15,6 +15,7 @@
     "LICENSE"
   ],
   "bin": {
+    "scribe": "./dist/index.mjs",
     "scb": "./dist/index.mjs"
   },
   "exports": {},

--- a/packages/cli/src/cli-output.ts
+++ b/packages/cli/src/cli-output.ts
@@ -1,0 +1,58 @@
+import { isAbsolute, relative, sep } from "node:path";
+
+export type OutputKind = "success" | "warning" | "error" | "accent";
+
+const ansi = {
+  success: "32",
+  warning: "33",
+  error: "31",
+  accent: "36"
+} as const;
+
+export function supportsColor(
+  isTTY: boolean,
+  env: Readonly<Record<string, string | undefined>>
+): boolean {
+  return isTTY && !("NO_COLOR" in env) && env.TERM !== "dumb";
+}
+
+export function colorize(value: string, kind: OutputKind, enabled: boolean): string {
+  return enabled ? `\u001B[${ansi[kind]}m${value}\u001B[0m` : value;
+}
+
+export function displayPath(root: string, path: string): string {
+  const value = relative(root, path);
+  if (value === "") return ".";
+  return value === ".." || value.startsWith(`..${sep}`) || isAbsolute(value) ? path : value;
+}
+
+export function commandArgument(value: string): string {
+  return /[\s"']/u.test(value) ? JSON.stringify(value) : value;
+}
+
+export function suggestClosest(input: string, candidates: readonly string[]): string | undefined {
+  const ranked = candidates
+    .map((candidate) => ({ candidate, distance: editDistance(input, candidate) }))
+    .sort((left, right) => left.distance - right.distance || left.candidate.localeCompare(right.candidate));
+  const best = ranked[0];
+  if (!best || best.distance > 2 || ranked[1]?.distance === best.distance) return undefined;
+  return best.candidate;
+}
+
+function editDistance(left: string, right: string): number {
+  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+    const current = [leftIndex];
+    for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+      const substitution = previous[rightIndex - 1] as number
+        + (left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1);
+      current[rightIndex] = Math.min(
+        (current[rightIndex - 1] as number) + 1,
+        (previous[rightIndex] as number) + 1,
+        substitution
+      );
+    }
+    previous.splice(0, previous.length, ...current);
+  }
+  return previous[right.length] as number;
+}

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { afterEach, expect, it, vi } from "vitest";
 
@@ -19,12 +19,35 @@ it("prints readable help and succeeds", async () => {
   const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 
   expect(await main(["--help"])).toBe(0);
-  expect(write.mock.calls.join("\n")).toContain("scb validate <article.mdx> [--strict]");
-  expect(write.mock.calls.join("\n")).toContain("scb init [--dry-run]");
-  expect(write.mock.calls.join("\n")).toContain("scb studio <article.mdx>");
-  expect(write.mock.calls.join("\n")).toContain("public alpha");
-  expect(write.mock.calls.join("\n")).not.toContain("beta");
-  expect(write.mock.calls.join("\n")).toContain("host-owned React site");
+  const output = write.mock.calls.join("\n");
+  expect(output).toContain("scribe <command> [options]");
+  expect(output).toContain("init");
+  expect(output).toContain("validate");
+  expect(output).toContain("studio");
+  expect(output).toContain("scribe init --dry-run");
+  expect(output).toContain("scribe validate ./content/article.mdx");
+  expect(output).toContain("scribe studio ./content/article.mdx");
+  expect(output).toContain("public alpha");
+  expect(output).not.toContain("beta");
+  expect(output).toContain("host-owned React site");
+  expect(output).not.toContain("--host-css <file>] [--port 4317]");
+});
+
+it("prints focused help for every public command", async () => {
+  const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+  expect(await main(["validate", "--help"])).toBe(0);
+  expect(write.mock.calls.join("\n")).toContain("scribe validate <article.mdx> [--strict]");
+  expect(write.mock.calls.join("\n")).toContain("Examples");
+  expect(write.mock.calls.join("\n")).not.toContain("scribe studio");
+
+  write.mockClear();
+  expect(await main(["init", "--help"])).toBe(0);
+  expect(write.mock.calls.join("\n")).toContain("scribe init --mode foundation");
+
+  write.mockClear();
+  expect(await main(["studio", "--help"])).toBe(0);
+  expect(write.mock.calls.join("\n")).toContain("scribe studio <article.mdx> [options]");
 });
 
 it("uses status 2 when no command is supplied", async () => {
@@ -32,7 +55,7 @@ it("uses status 2 when no command is supplied", async () => {
   const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
   expect(await main([])).toBe(2);
-  expect(stderr.mock.calls.join("\n")).toContain("Expected a command");
+  expect(stderr.mock.calls.join("\n")).toContain("Run `scribe --help`");
 });
 
 it("validates a file and reports unsupported languages as non-fatal warnings", async () => {
@@ -42,7 +65,8 @@ it("validates a file and reports unsupported languages as non-fatal warnings", a
 
   expect(await main(["validate", path])).toBe(0);
   expect(stderr.mock.calls.join("\n")).toContain('[warning SCB1003] Unsupported code language "not-a-real-language"; falling back to plaintext.');
-  expect(stdout.mock.calls.join("\n")).toContain(`Validated ${path} with 1 warning.`);
+  expect(stdout.mock.calls.join("\n")).toContain("Validation passed");
+  expect(stdout.mock.calls.join("\n")).toContain("1 warning");
 });
 
 it("fails strict validation for unsupported languages without a stack trace", async () => {
@@ -53,7 +77,11 @@ it("fails strict validation for unsupported languages without a stack trace", as
   expect(await main(["validate", path, "--strict"])).toBe(1);
   const output = stderr.mock.calls.join("\n");
   expect(output).toContain("[error SCB1003]");
+  expect(output).toContain("Validation failed");
+  expect(output).toContain("Next");
+  expect(output).toContain(`scribe validate ${JSON.stringify(path)} --strict`);
   expect(output).not.toContain("at async");
+  expect(output).not.toMatch(/\u001b\[/u);
 });
 
 it("returns a nonzero status with actionable component diagnostics", async () => {
@@ -101,37 +129,60 @@ it("explains the accepted syntax for malformed code metadata", async () => {
   );
 });
 
-it("uses status 2 for invalid command usage", async () => {
+it("suggests the nearest valid command for invalid usage", async () => {
   vi.spyOn(process.stdout, "write").mockImplementation(() => true);
   const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
-  expect(await main(["inspect", "article.mdx"])).toBe(2);
-  expect(stderr.mock.calls.join("\n")).toContain('Unknown command "inspect".');
+  expect(await main(["validte", "article.mdx"])).toBe(2);
+  expect(stderr.mock.calls.join("\n")).toContain('Unknown command "validte". Did you mean "validate"?');
 });
 
-it("prints command-specific init help", async () => {
-  const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+it("suggests the nearest valid option and keeps usage failures on status 2", async () => {
+  vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
-  expect(await main(["init", "--help"])).toBe(0);
-  expect(write.mock.calls.join("\n")).toContain("scb init --mode foundation");
+  expect(await main(["validate", "article.mdx", "--strct"])).toBe(2);
+  expect(stderr.mock.calls.join("\n")).toContain('Unknown option "--strct". Did you mean "--strict"?');
+  expect(stderr.mock.calls.join("\n")).toContain("scribe validate --help");
 });
 
-it("recognizes a symlinked installed binary as the entrypoint", () => {
+it("prefers project-relative paths in validation output", async () => {
+  const path = await fixture("# Relative diagnostics\n");
+  const stdout = vi.fn();
+
+  expect(await main(["validate", "article.mdx"], { cwd: dirname(path), stdout })).toBe(0);
+  expect(stdout.mock.calls.join("\n")).toContain("article.mdx");
+  expect(stdout.mock.calls.join("\n")).not.toContain(path);
+});
+
+it("uses restrained ANSI only for an interactive terminal and respects NO_COLOR", async () => {
+  const path = await fixture("# Color contract\n");
+  const interactive = vi.fn();
+  const noColor = vi.fn();
+
+  expect(await main(["validate", path], { cwd: dirname(path), stdout: interactive, isTTY: true, env: {} })).toBe(0);
+  expect(interactive.mock.calls.join("\n")).toMatch(/\u001b\[/u);
+
+  expect(await main(["validate", path], { cwd: dirname(path), stdout: noColor, isTTY: true, env: { NO_COLOR: "1" } })).toBe(0);
+  expect(noColor.mock.calls.join("\n")).not.toMatch(/\u001b\[/u);
+});
+
+it.each(["scribe", "scb"])("recognizes the symlinked %s binary as the entrypoint", (binary) => {
   const realpath = vi.fn((path: string) =>
-    path.endsWith("/scb") ? "/package/dist/index.mjs" : path
+    path.endsWith(`/${binary}`) ? "/package/dist/index.mjs" : path
   );
 
   expect(
     isMainModule(
       "file:///package/dist/index.mjs",
-      "/consumer/node_modules/.bin/scb",
+      `/consumer/node_modules/.bin/${binary}`,
       realpath
     )
   ).toBe(true);
 });
 
 async function fixture(source: string): Promise<string> {
-  const directory = await mkdtemp(join(tmpdir(), "scribe-cli-test-"));
+  const directory = await mkdtemp(join(tmpdir(), "scribe cli test "));
   const path = join(directory, "article.mdx");
   await writeFile(path, source);
   return path;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 
 import { compileScribeMdx } from "@scribe-sdk/mdx";
 
+import { colorize, commandArgument, displayPath, suggestClosest, supportsColor } from "./cli-output.js";
 import { initHelp, runInit } from "./init.js";
 import { runStudio, studioHelp } from "./studio.js";
 
@@ -14,82 +15,133 @@ export const version = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8")
 ).version as string;
 
-const help = `Scribe ${version}
+const help = `Scribe ${version} · public alpha
 
-Scribe is in public alpha. Add technical-publishing structure and behavior to a host-owned React site.
+Technical-publishing structure and behavior for a host-owned React site.
 
-Usage:
-  scb validate <article.mdx> [--strict]
-  scb init [--dry-run] [--mode foundation|default|tailwind] [--yes]
-  scb studio <article.mdx> [--mode foundation|default|tailwind] [--host-css <file>] [--port 4317] [--no-open]
-  scb --help
-  scb --version
+Usage
+  scribe <command> [options]
 
-Options:
-  --strict    Treat warnings, including plaintext language fallbacks, as errors.
-  -h, --help  Show this help.
-  -v, --version  Show the installed Scribe version.
+Commands
+  init       Inspect and deliberately configure Scribe in the current React project.
+  validate   Compile and validate one Markdown or MDX article.
+  studio     Open the local, source-authoritative authoring Studio.
+
+Examples
+  scribe init --dry-run
+  scribe validate ./content/article.mdx
+  scribe studio ./content/article.mdx
+
+Global options
+  -h, --help       Show this help.
+  -v, --version    Show the installed Scribe version.
+
+Run \`scribe <command> --help\` for command options.
 `;
 
-export async function main(args: readonly string[] = process.argv.slice(2)): Promise<number> {
+const validateHelp = `Compile and validate one article through Scribe's production MDX pipeline.
+
+Usage
+  scribe validate <article.mdx> [--strict]
+
+Examples
+  scribe validate ./content/article.mdx
+  scribe validate ./content/article.mdx --strict
+
+Options
+  --strict      Treat warnings, including plaintext language fallback, as errors.
+  -h, --help    Show this command help.
+`;
+
+export interface MainDependencies {
+  readonly cwd?: string;
+  readonly stdout?: (value: string) => void;
+  readonly stderr?: (value: string) => void;
+  readonly isTTY?: boolean;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+}
+
+export async function main(
+  args: readonly string[] = process.argv.slice(2),
+  dependencies: MainDependencies = {}
+): Promise<number> {
+  const cwd = dependencies.cwd ?? process.cwd();
+  const stdout = dependencies.stdout ?? ((value: string) => process.stdout.write(value));
+  const stderr = dependencies.stderr ?? ((value: string) => process.stderr.write(value));
+  const color = supportsColor(
+    dependencies.isTTY ?? process.stdout.isTTY === true,
+    dependencies.env ?? process.env
+  );
   if (args.includes("--version") || args.includes("-v")) {
-    process.stdout.write(`${version}\n`);
+    stdout(`${version}\n`);
     return 0;
   }
-  if ((args.includes("--help") || args.includes("-h")) && args[0] !== "init" && args[0] !== "studio") {
-    process.stdout.write(help);
+  if (args[0] === "--help" || args[0] === "-h") {
+    stdout(help);
     return 0;
   }
   if (args.length === 0) {
-    process.stderr.write("Expected a command. Run `scb --help` for usage.\n");
+    stderr("Expected a command. Run `scribe --help` for the three supported actions.\n");
     return 2;
   }
 
   const [command, ...rest] = args;
   if (command === "init") {
     if (rest.includes("--help") || rest.includes("-h")) {
-      process.stdout.write(initHelp);
+      stdout(initHelp);
       return 0;
     }
-    return runInit(rest, { version });
+    return runInit(rest, { version, cwd, stdout, stderr });
   }
   if (command === "studio") {
     if (rest.includes("--help") || rest.includes("-h")) {
-      process.stdout.write(studioHelp);
+      stdout(studioHelp);
       return 0;
     }
-    return runStudio(rest);
+    return runStudio(rest, { cwd, stdout, stderr });
   }
   if (command !== "validate") {
-    process.stderr.write(`Unknown command "${String(command)}". Run \`scb --help\` for usage.\n`);
+    const suggestion = suggestClosest(String(command), ["init", "validate", "studio"]);
+    stderr(`Unknown command "${String(command)}".${suggestion === undefined ? "" : ` Did you mean "${suggestion}"?`}\nRun \`scribe --help\` for the supported actions.\n`);
     return 2;
+  }
+  if (rest.includes("--help") || rest.includes("-h")) {
+    stdout(validateHelp);
+    return 0;
   }
 
   const strict = rest.includes("--strict");
   const unsupportedOptions = rest.filter((argument) => argument.startsWith("-") && argument !== "--strict");
   const paths = rest.filter((argument) => !argument.startsWith("-"));
   if (unsupportedOptions.length > 0 || paths.length !== 1) {
-    const detail = unsupportedOptions.length > 0
-      ? `Unknown option "${unsupportedOptions[0]}".`
+    const unknown = unsupportedOptions[0];
+    const suggestion = unknown === undefined ? undefined : suggestClosest(unknown, ["--strict", "--help"]);
+    const detail = unknown !== undefined
+      ? `Unknown option "${unknown}".${suggestion === undefined ? "" : ` Did you mean "${suggestion}"?`}`
       : "Expected exactly one MDX file.";
-    process.stderr.write(`${detail} Usage: scb validate <article.mdx> [--strict]\n`);
+    stderr(`${detail}\nRun \`scribe validate --help\` for accepted arguments.\n`);
     return 2;
   }
 
-  return validate(paths[0] as string, strict);
+  return validate(paths[0] as string, strict, { cwd, stdout, stderr, color });
 }
 
-async function validate(inputPath: string, strict: boolean): Promise<number> {
-  const path = resolve(inputPath);
+async function validate(
+  inputPath: string,
+  strict: boolean,
+  output: Required<Pick<MainDependencies, "cwd" | "stdout" | "stderr">> & { readonly color: boolean }
+): Promise<number> {
+  const path = resolve(output.cwd, inputPath);
+  const shownPath = displayPath(output.cwd, path);
   try {
     const source = await readFile(path, "utf8");
     const file = await compileScribeMdx({ path, value: source }, { strict });
-    for (const message of file.messages) process.stderr.write(`${formatDiagnostic(path, message, "warning")}\n`);
+    for (const message of file.messages) output.stderr(`${formatDiagnostic(shownPath, message, "warning")}\n`);
     const count = file.messages.length;
-    process.stdout.write(`Validated ${path}${count === 0 ? "." : ` with ${count} warning${count === 1 ? "" : "s"}.`}\n`);
+    output.stdout(`${colorize("Success", "success", output.color)}  Validation passed\n  ${shownPath}\n${count === 0 ? "" : `${colorize("Warning", "warning", output.color)}  ${count} warning${count === 1 ? "" : "s"} reported\n`}\n`);
     return 0;
   } catch (error) {
-    process.stderr.write(`${formatDiagnostic(path, error, "error")}\n`);
+    output.stderr(`${formatDiagnostic(shownPath, error, "error")}\n${colorize("Error", "error", output.color)}  Validation failed\n  ${shownPath}\n\nNext\n  Fix the diagnostic above, then run \`scribe validate ${commandArgument(shownPath)}${strict ? " --strict" : ""}\` again.\n`);
     return 1;
   }
 }

--- a/packages/cli/src/init.test.ts
+++ b/packages/cli/src/init.test.ts
@@ -89,10 +89,30 @@ it("keeps dry runs pure and reports every proposed change", async () => {
 
   expect(await runInit(["--dry-run"], { cwd, version: "0.1.0-alpha.2", stdout })).toBe(0);
   expect(await readFile(join(cwd, "src/index.css"), "utf8")).toBe(before);
-  expect(stdout.mock.calls.join("\n")).toContain("Scribe public alpha init dry run");
-  expect(stdout.mock.calls.join("\n")).not.toContain("beta");
-  expect(stdout.mock.calls.join("\n")).toContain("Recommended style mode: default");
-  expect(stdout.mock.calls.join("\n")).toContain("src/index.css");
+  const output = stdout.mock.calls.join("\n");
+  expect(output).toContain("Scribe init — dry run");
+  expect(output).not.toContain("beta");
+  expect(output).toMatch(/Detected\n[\s\S]*React 19\.2\.7/u);
+  expect(output).toMatch(/Recommendation\n[\s\S]*default/u);
+  expect(output).toMatch(/Commands\n/u);
+  expect(output).toMatch(/File changes\n[\s\S]*src\/index\.css/u);
+  expect(output).toMatch(/Manual steps\n/u);
+  expect(output).toMatch(/Next\n/u);
+  expect(output).not.toContain(cwd);
+});
+
+it("separates detected integration warnings from manual steps", async () => {
+  const cwd = await project({
+    "package.json": JSON.stringify({ ...packages, dependencies: { ...packages.dependencies, vite: "8.1.3", "rehype-pretty-code": "0.14.1" } }),
+    "src/index.css": "body { margin: 0; }\n",
+    "vite.config.ts": 'import prettyCode from "rehype-pretty-code";\n'
+  });
+  const stdout = vi.fn();
+
+  expect(await runInit(["--dry-run"], { cwd, version: "0.1.0-alpha.2", stdout })).toBe(0);
+  const output = stdout.mock.calls.join("\n");
+  expect(output).toMatch(/Warnings\n[\s\S]*existing syntax highlighter/u);
+  expect(output.indexOf("Warnings")).toBeLessThan(output.indexOf("Manual steps"));
 });
 
 it("applies one style import and remains idempotent", async () => {
@@ -159,6 +179,9 @@ it("preserves CRLF files while adding the selected import", async () => {
 
 it("rejects invalid options and unresolved projects with usage status", async () => {
   const cwd = await project({ "package.json": JSON.stringify({ dependencies: { react: "19.2.7" } }) });
-  expect(await runInit(["--mode", "loud"], { cwd, version: "0.1.0-alpha.2", stderr: vi.fn() })).toBe(2);
+  const stderr = vi.fn();
+  expect(await runInit(["--mode", "loud"], { cwd, version: "0.1.0-alpha.2", stderr })).toBe(2);
+  expect(await runInit(["--dryrun"], { cwd, version: "0.1.0-alpha.2", stderr })).toBe(2);
+  expect(stderr.mock.calls.join("\n")).toContain('Did you mean "--dry-run"?');
   expect(await runInit(["--dry-run"], { cwd, version: "0.1.0-alpha.2", stderr: vi.fn() })).toBe(2);
 });

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -4,6 +4,8 @@ import { access, mkdir, readFile, readdir, rename, writeFile } from "node:fs/pro
 import { basename, dirname, relative, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 
+import { suggestClosest } from "./cli-output.js";
+
 export type StyleMode = "foundation" | "default" | "tailwind";
 export type PackageManager = "bun" | "npm" | "pnpm" | "yarn";
 
@@ -39,6 +41,7 @@ export interface InitPlan {
   readonly ambiguities: readonly string[];
   readonly commands: readonly (readonly string[])[];
   readonly changes: readonly FileChange[];
+  readonly warnings: readonly string[];
   readonly manualSteps: readonly string[];
 }
 
@@ -73,14 +76,15 @@ const styleCandidates = [
 
 export const initHelp = `Initialize Scribe deliberately inside an existing React project.
 
-Usage:
-  scb init --dry-run
-  scb init [--yes]
-  scb init --mode foundation [--yes]
-  scb init --mode default [--yes]
-  scb init --mode tailwind [--yes]
+Usage
+  scribe init [options]
 
-Options:
+Examples
+  scribe init --dry-run
+  scribe init
+  scribe init --mode foundation --yes
+
+Options
   --dry-run       Inspect and print the plan without installing or writing files.
   --mode <mode>   Select foundation, default, or tailwind styling.
   --yes           Apply the reported plan without an interactive confirmation.
@@ -144,6 +148,7 @@ export async function planInit(root: string, explicitMode: StyleMode | undefined
   if (missingCli.length > 0) commands.push(installCommand(inspection.packageManager, missingCli, true));
 
   const changes: FileChange[] = [];
+  const warnings: string[] = [];
   const manualSteps: string[] = [];
   if (mode !== undefined) {
     const importLine = `@import "@scribe-sdk/styles/${mode}.css";`;
@@ -188,10 +193,10 @@ export async function planInit(root: string, explicitMode: StyleMode | undefined
     }
   }
   if (inspection.hasSyntaxHighlighter) {
-    manualSteps.push("An existing syntax highlighter was detected. Review the overlap manually; init will not remove or replace it.");
+    warnings.push("An existing syntax highlighter was detected. Review the overlap manually; init will not remove or replace it.");
   }
 
-  return { inspection, ...(mode === undefined ? {} : { mode }), reason, ambiguities, commands, changes, manualSteps };
+  return { inspection, ...(mode === undefined ? {} : { mode }), reason, ambiguities, commands, changes, warnings, manualSteps };
 }
 
 export async function resolveProjectStyleMode(
@@ -288,7 +293,7 @@ export async function runInit(args: readonly string[], dependencies: InitDepende
     return 1;
   }
 
-  stdout(`Scribe initialized in ${plan.mode} mode.\nModified: ${plan.changes.length === 0 ? "none" : plan.changes.map((change) => displayPath(plan.inspection.root, change.path)).join(", ")}\nSkipped: existing configuration was preserved.\nVerify with: ${verificationCommand(plan.inspection.packageManager)}\nRollback: revert only the files listed above and remove packages added by the displayed commands.\n`);
+  stdout(`Success  Scribe initialized\n  Mode           ${plan.mode}\n\nChanged files\n${plan.changes.length === 0 ? "  none" : plan.changes.map((change) => `  ${displayPath(plan.inspection.root, change.path)}`).join("\n")}\n\nPreserved\n  Existing configuration outside the reported plan.\n\nNext\n  Run \`${verificationCommand(plan.inspection.packageManager)}\`.\n  Roll back by reverting only the files above and removing packages from the displayed commands.\n`);
   return 0;
 }
 
@@ -311,7 +316,11 @@ function parseInitArguments(args: readonly string[]): { readonly dryRun: boolean
       const value = argument.slice("--mode=".length);
       if (!modes.has(value as StyleMode)) return `Invalid --mode value "${value}". Expected one of: foundation, default, tailwind.`;
       mode = value as StyleMode;
-    } else return `Unknown init option "${String(argument)}".`;
+    } else {
+      const value = String(argument);
+      const suggestion = suggestClosest(value, ["--dry-run", "--mode", "--yes", "--help"]);
+      return `Unknown init option "${value}".${suggestion === undefined ? "" : ` Did you mean "${suggestion}"?`}`;
+    }
   }
   return { dryRun, yes, help, ...(mode === undefined ? {} : { mode }) };
 }
@@ -327,19 +336,40 @@ function formatPlan(plan: InitPlan, dryRun: boolean): string {
     plan.inspection.hasNextMdx ? "@next/mdx" : undefined
   ].filter(Boolean).join(", ");
   const lines = [
-    dryRun ? "Scribe public alpha init dry run — no files or packages will be changed." : "Scribe public alpha initialization plan.",
-    `Project: ${plan.inspection.root}`,
-    `Detected stack: ${detected}`,
-    `Package manager: ${plan.inspection.packageManager}`,
-    `Recommended style mode: ${plan.mode ?? "unresolved"}${plan.reason === "" ? "" : ` — ${plan.reason}`}`,
-    "Proposed commands:",
+    `Scribe init — ${dryRun ? "dry run" : "reviewed plan"}`,
+    dryRun ? "No files or packages will be changed." : "Review this plan before confirming changes.",
+    "",
+    "Detected",
+    "  Project          .",
+    `  Stack            ${detected}`,
+    `  Package manager  ${plan.inspection.packageManager}`,
+    "",
+    "Recommendation",
+    `  Mode    ${plan.mode ?? "unresolved"}`,
+    ...(plan.reason === "" ? [] : [`  Reason  ${plan.reason}`]),
+    "",
+    "Commands",
     ...(plan.commands.length === 0 ? ["  none"] : plan.commands.map((command) => `  ${command.join(" ")}`)),
-    "Proposed file changes:",
+    "",
+    "File changes",
     ...(plan.changes.length === 0 ? ["  none"] : plan.changes.map((change) => `  ${displayPath(plan.inspection.root, change.path)} — ${change.description}`)),
-    "Manual steps:",
+    "",
+    "Warnings",
+    ...(plan.warnings.length === 0 ? ["  none"] : plan.warnings.map((warning) => `  ${warning}`)),
+    "",
+    "Manual steps",
     ...(plan.manualSteps.length === 0 ? ["  none"] : plan.manualSteps.map((step) => `  ${step}`))
   ];
-  if (plan.ambiguities.length > 0) lines.push("Unresolved:", ...plan.ambiguities.map((value) => `  ${value}`));
+  if (plan.ambiguities.length > 0) lines.push("", "Ambiguities", ...plan.ambiguities.map((value) => `  ${value}`));
+  lines.push(
+    "",
+    "Next",
+    plan.ambiguities.length > 0 || plan.mode === undefined
+      ? "  Resolve the ambiguities above, then rerun `scribe init --dry-run`."
+      : dryRun
+        ? "  Review this plan, then run `scribe init` to confirm and apply it."
+        : "  Confirm only after the detected stack and proposed changes are correct."
+  );
   return `${lines.join("\n")}\n`;
 }
 
@@ -388,10 +418,10 @@ function installCommand(manager: PackageManager, packages: readonly string[], de
 }
 
 function verificationCommand(manager: PackageManager): string {
-  if (manager === "bun") return "bunx scb validate path/to/article.mdx";
-  if (manager === "pnpm") return "pnpm exec scb validate path/to/article.mdx";
-  if (manager === "yarn") return "yarn scb validate path/to/article.mdx";
-  return "npx scb validate path/to/article.mdx";
+  if (manager === "bun") return "bunx scribe validate path/to/article.mdx";
+  if (manager === "pnpm") return "pnpm exec scribe validate path/to/article.mdx";
+  if (manager === "yarn") return "yarn scribe validate path/to/article.mdx";
+  return "npx scribe validate path/to/article.mdx";
 }
 
 function insertCssImport(existing: string, importLine: string): string {

--- a/packages/cli/src/studio.test.ts
+++ b/packages/cli/src/studio.test.ts
@@ -5,7 +5,7 @@ import { createServer as createNetServer } from "node:net";
 
 import { afterEach, expect, it, vi } from "vitest";
 
-import { parseStudioArguments, runStudio, startStudio, type StudioHandle } from "./studio.js";
+import { formatStudioStartup, parseStudioArguments, runStudio, startStudio, type StudioHandle } from "./studio.js";
 
 const handles: StudioHandle[] = [];
 afterEach(async () => Promise.all(handles.splice(0).map((handle) => handle.close())));
@@ -34,8 +34,17 @@ it("parses the documented studio command surface and rejects unknown flags", () 
     open: true,
     help: false
   });
-  expect(parseStudioArguments(["content/a.mdx", "--wat"])).toMatchObject({ error: expect.stringContaining("--wat") });
+  expect(parseStudioArguments(["content/a.mdx", "--no-opn"])).toEqual({ error: 'Unknown studio option "--no-opn". Did you mean "--no-open"?' });
   expect(parseStudioArguments(["content/a.txt"])).toMatchObject({ error: expect.stringContaining(".md or .mdx") });
+});
+
+it("formats Studio startup with a project-relative source path", () => {
+  const root = join(tmpdir(), "scribe host");
+  const source = join(root, "content", "peer notes.mdx");
+  const output = formatStudioStartup(root, source, "foundation", "http://127.0.0.1:4317");
+
+  expect(output).toMatch(/Source  content[\\/]peer notes\.mdx/u);
+  expect(output).not.toContain(root);
 });
 
 it("requires an explicit Studio mode when project detection is ambiguous", async () => {

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -12,6 +12,7 @@ import { compileScribeMdx, createScribeMdxOptions } from "@scribe-sdk/mdx";
 import react from "@vitejs/plugin-react";
 import { createServer as createViteServer, normalizePath, type Plugin, type ViteDevServer } from "vite";
 
+import { displayPath, suggestClosest } from "./cli-output.js";
 import { resolveProjectStyleMode, type StyleMode } from "./init.js";
 import { acceptRichCandidate, createRichProjection, type RichProjection } from "./rich-preservation.js";
 import { studioClientModule, studioStyles, type StudioClientImports } from "./studio-ui.js";
@@ -77,10 +78,14 @@ const maxRequestBytes = 5 * 1024 * 1024;
 
 export const studioHelp = `Open Scribe's local, source-authoritative MDX Studio.
 
-Usage:
-  scb studio <article.mdx> [options]
+Usage
+  scribe studio <article.mdx> [options]
 
-Options:
+Examples
+  scribe studio ./content/article.mdx
+  scribe studio ./content/article.mdx --mode foundation --no-open
+
+Options
   --mode <mode>     Override detected foundation, default, or tailwind CSS.
   --host-css <path> Load one explicit local host stylesheet.
   --port <number>   Use a specific loopback port (default: 4317).
@@ -115,7 +120,10 @@ export function parseStudioArguments(args: readonly string[]): StudioArguments |
       if (!Number.isInteger(value) || value < 1 || value > 65_535) return { error: "--port requires an integer from 1 to 65535." };
       port = value;
       index += 1;
-    } else if (argument?.startsWith("-")) return { error: `Unknown studio option "${argument}".` };
+    } else if (argument?.startsWith("-")) {
+      const suggestion = suggestClosest(argument, ["--mode", "--host-css", "--port", "--no-open", "--help"]);
+      return { error: `Unknown studio option "${argument}".${suggestion === undefined ? "" : ` Did you mean "${suggestion}"?`}` };
+    }
     else if (path === undefined) path = argument;
     else return { error: "Expected exactly one Markdown or MDX source file." };
   }
@@ -304,7 +312,7 @@ export async function runStudio(
     return 1;
   }
 
-  stdout(`Scribe Studio: ${handle.origin}\nSource remains authoritative; save explicitly from the Studio or your editor.\n`);
+  stdout(formatStudioStartup(dependencies.cwd ?? process.cwd(), parsed.path, mode, handle.origin));
   await new Promise<void>((resolveStop) => {
     const stop = () => resolveStop();
     process.once("SIGINT", stop);
@@ -312,6 +320,11 @@ export async function runStudio(
   });
   await handle.close();
   return 0;
+}
+
+export function formatStudioStartup(root: string, sourcePath: string, mode: StyleMode, origin: string): string {
+  const source = displayPath(root, resolve(root, sourcePath));
+  return `Scribe Studio\n  ${origin}\n  Source  ${source}\n  Mode    ${mode}\n\nSource remains authoritative. Save explicitly from Studio or your editor.\nPress Ctrl+C to stop.\n`;
 }
 
 function createStudioPlugin(context: {

--- a/packages/mdx/README.md
+++ b/packages/mdx/README.md
@@ -15,7 +15,7 @@ Scribe is not a hosted blogging platform, CMS, website builder, rich-text editor
 | `@scribe-sdk/react` | Publication boundary, component map, and editorial primitives | package root |
 | `@scribe-sdk/styles` | Scoped publishing mechanics and optional editorial presentation | `/foundation.css`, `/default.css`, `/tailwind.css` |
 | `@scribe-sdk/mdx` | Shared compile-time MDX configuration and validation | package root, `/next`, `/next-remote`, `/remark`, `/rehype` |
-| `@scribe-sdk/cli` | Validation, deliberate setup, and the local authoring Studio | `scb` binary |
+| `@scribe-sdk/cli` | Validation, deliberate setup, and the local authoring Studio | `scribe` binary |
 
 Each installed package includes the same canonical `SKILL.md`. Agents can discover it at `node_modules/@scribe-sdk/<package>/SKILL.md`; the repository source of truth is [`SKILL.md`](./SKILL.md).
 
@@ -35,31 +35,35 @@ npm install @scribe-sdk/react@alpha @scribe-sdk/styles@alpha @scribe-sdk/mdx@alp
 npm install --save-dev @scribe-sdk/cli@alpha
 ```
 
+Project-local CLI installation is recommended so every contributor uses the same prerelease. A user-level CLI is also supported through `bun add --global @scribe-sdk/cli@alpha` or `npm install --global @scribe-sdk/cli@alpha`; the project still owns its runtime Scribe dependencies.
+
 Package installation is inert: it does not edit source files, run project detection, or make network calls beyond normal package-manager behavior. Inspect a proposed integration explicitly:
 
 ```bash
-bunx scb init --dry-run
+bunx scribe init --dry-run
 ```
 
 With npm, run the same locally installed binary through `npx`:
 
 ```bash
-npx scb init --dry-run
+npx scribe init --dry-run
 ```
 
 ### CLI reference
 
-Run CLI commands through `bunx scb` or `npx scb` after installing `@scribe-sdk/cli` locally. The examples below use `scb` to show the command surface without repeating both runners.
+Run CLI commands through `bunx scribe` or `npx scribe` after installing `@scribe-sdk/cli` locally. The examples below use `scribe` to show the command surface without repeating both runners.
+
+`scribe` is the primary executable. The prerelease-only `scb` compatibility alias remains available with identical behavior for existing alpha users; new integrations should use `scribe`.
 
 | Command | Purpose |
 | --- | --- |
-| `scb init [--dry-run] [--mode <mode>] [--yes]` | Inspect and deliberately initialize Scribe in the current React project; mode is `foundation`, `default`, or `tailwind` |
-| `scb validate <article.mdx> [--strict]` | Compile and validate one article without executing the complete host application |
-| `scb studio <article> [--mode <mode>] [--host-css <file>] [--port <number>] [--no-open]` | Open the local, source-authoritative Markdown/MDX Studio; mode is `foundation`, `default`, or `tailwind` |
-| `scb --help` | Show the installed CLI command surface |
-| `scb --version` | Print the installed Scribe version |
+| `scribe init [--dry-run] [--mode <mode>] [--yes]` | Inspect and deliberately initialize Scribe in the current React project; mode is `foundation`, `default`, or `tailwind` |
+| `scribe validate <article.mdx> [--strict]` | Compile and validate one article without executing the complete host application |
+| `scribe studio <article> [--mode <mode>] [--host-css <file>] [--port <number>] [--no-open]` | Open the local, source-authoritative Markdown/MDX Studio; mode is `foundation`, `default`, or `tailwind` |
+| `scribe --help` | Show the installed CLI command surface |
+| `scribe --version` | Print the installed Scribe version |
 
-Use `scb init --help` or `scb studio --help` for command-specific option summaries. CLI exit codes are consistent: `0` means success, `1` means execution or article-compilation failure, and `2` means invalid usage or unresolved initialization configuration.
+Use `scribe init --help`, `scribe validate --help`, or `scribe studio --help` for focused option summaries and examples. CLI exit codes are consistent: `0` means success, `1` means execution or article-compilation failure, and `2` means invalid usage or unresolved initialization configuration.
 
 ## Choose a style mode
 
@@ -96,15 +100,15 @@ Scribe ships no fonts and does not clone Tailwind Typography. In Tailwind mode, 
 Run initialization deliberately from the host project's root after installation:
 
 ```bash
-bunx scb init --dry-run
-bunx scb init
+bunx scribe init --dry-run
+bunx scribe init
 ```
 
 With npm:
 
 ```bash
-npx scb init --dry-run
-npx scb init
+npx scribe init --dry-run
+npx scribe init
 ```
 
 `init` inspects React, Next.js or Vite, Tailwind v3/v4, Typography and `.prose`, existing MDX integrations and plugins, syntax highlighters, global CSS, component maps, and current Scribe wiring. It recommends `foundation`, `default`, or `tailwind`, reports every proposed command and file edit, and asks before mutation. Use `--mode foundation|default|tailwind` to override the recommendation or `--yes` for a reviewed non-interactive plan.
@@ -322,7 +326,7 @@ Supported metadata is explicit:
 | additions | `add="4-6"` | Marks added lines |
 | removals | `remove="2"` | Marks removed lines |
 
-Ranges are one-based, comma-separated, and inclusive. Unknown or malformed fields fail compilation. Unsupported languages warn and fall back to plaintext by default. Enable strict behavior with `createScribeMdxOptions({ strict: true })`, `createScribeNextMdxOptions({ strict: true })`, or `scb validate article.mdx --strict`.
+Ranges are one-based, comma-separated, and inclusive. Unknown or malformed fields fail compilation. Unsupported languages warn and fall back to plaintext by default. Enable strict behavior with `createScribeMdxOptions({ strict: true })`, `createScribeNextMdxOptions({ strict: true })`, or `scribe validate article.mdx --strict`.
 
 Inline backticks remain visually distinct from framed code blocks.
 
@@ -391,18 +395,18 @@ Reduced-motion preferences disable nonessential transitions. Print styles remove
 Open a source-authoritative local workspace for one Markdown or MDX file:
 
 ```bash
-bunx scb studio ./content/article.mdx
-bunx scb studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
+bunx scribe studio ./content/article.mdx
+bunx scribe studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
 ```
 
 With npm:
 
 ```bash
-npx scb studio ./content/article.mdx
-npx scb studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
+npx scribe studio ./content/article.mdx
+npx scribe studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
 ```
 
-Studio detects the project style mode using the same rules as `scb init`; pass `--mode` only to override that result deliberately. An ambiguous project exits with guidance instead of silently choosing a visual preset. Port `4317` remains the default.
+Studio detects the project style mode using the same rules as `scribe init`; pass `--mode` only to override that result deliberately. An ambiguous project exits with guidance instead of silently choosing a visual preset. Port `4317` remains the default.
 
 Studio has exactly two authoring modes. Markdown mode keeps the source editable beside the production renderer and has no formatting toolbar. Rich Text mode is a constrained visual helper for ordinary Markdown; it provides a minimal toolbar, writes accepted edits back to the canonical Markdown draft, and shows a read-only Markdown mirror by default. Its secondary pane can switch to the same production renderer. Unsupported MDX, frontmatter, HTML, JSX, expressions, and metadata-bearing code fences remain byte-identical protected blocks with an **Edit in Markdown** action. Rich Text may refuse to edit a construct; it never pretends to support one and silently rewrites the source.
 
@@ -419,34 +423,34 @@ Use `--port 4317` to select a port and `--no-open` for headless workflows. Stop 
 Validate one article through the production compiler:
 
 ```bash
-bunx scb validate ./content/article.mdx
-bunx scb validate ./content/article.mdx --strict
+bunx scribe validate ./content/article.mdx
+bunx scribe validate ./content/article.mdx --strict
 ```
 
 With npm:
 
 ```bash
-npx scb validate ./content/article.mdx
-npx scb validate ./content/article.mdx --strict
+npx scribe validate ./content/article.mdx
+npx scribe validate ./content/article.mdx --strict
 ```
 
-`scb validate` checks MDX syntax, Scribe code metadata, supported static component metadata, compile-time highlighting, and article-level diagnostics. It does not execute or validate the complete consumer application.
+`scribe validate` checks MDX syntax, Scribe code metadata, supported static component metadata, compile-time highlighting, and article-level diagnostics. It does not execute or validate the complete consumer application.
 
 - Exit `0`: validation succeeded; warnings may have been printed.
 - Exit `1`: article compilation or strict validation failed.
 - Exit `2`: command usage was invalid.
 
-Diagnostics include the file, position when available, severity, stable code, and remediation. Unsupported languages use warning `SCB1003` and plaintext fallback unless strict mode is enabled. Run `scb --help` for the complete supported CLI surface.
+Diagnostics include the file, position when available, severity, stable code, and remediation. Unsupported languages use warning `SCB1003` and plaintext fallback unless strict mode is enabled. Run `scribe --help` for the complete supported CLI surface.
 
 If rendering differs between the Vite and Next builds, confirm that both use the matching `@scribe-sdk/mdx` version and the shared helper. If a table is not scrollable, confirm that the stylesheet is imported and the article renders beneath `.scribe`. Do not add host CSS solely to conceal a Scribe defect; reduce the case and report it at <https://github.com/aetosdios27/scribe/issues>.
 
 ## Migrating from `0.1.0-alpha.2`
 
 - Existing `default.css` imports remain supported and retain the complete editorial preset.
-- Established sites that already own article typography should switch to `foundation.css` after reviewing `scb init --dry-run` and before/after computed styles.
+- Established sites that already own article typography should switch to `foundation.css` after reviewing `scribe init --dry-run` and before/after computed styles.
 - Tailwind Typography sites should use `tailwind.css` and keep their `.prose` wrapper.
 - `next-mdx-remote/rsc` integrations should replace loader-shaped configuration with `createScribeRemoteMdxOptions()` from `@scribe-sdk/mdx/next-remote`.
-- Installation performs no migration. `scb init` reports and confirms any safe edits; existing plugins and highlighters remain untouched unless the owner changes them explicitly.
+- Installation performs no migration. `scribe init` reports and confirms any safe edits; existing plugins and highlighters remain untouched unless the owner changes them explicitly.
 
 ## Responsibility boundary
 

--- a/packages/mdx/SKILL.md
+++ b/packages/mdx/SKILL.md
@@ -36,10 +36,10 @@ Expected packages are `@scribe-sdk/react`, `@scribe-sdk/styles`, `@scribe-sdk/md
 Start with the deliberate detector:
 
 ```bash
-bunx scb init --dry-run
+bunx scribe init --dry-run
 ```
 
-Review the detected stack, recommended mode, touched files, commands, ambiguities, and existing highlighter warnings. Run `bunx scb init` only after the plan is safe. Installation itself is inert.
+Review the detected stack, recommended mode, touched files, commands, ambiguities, and existing highlighter warnings. Run `bunx scribe init` only after the plan is safe. Installation itself is inert.
 
 Choose exactly one style mode:
 
@@ -177,11 +177,11 @@ Scribe supplies color-scheme-aware styles. The host owns the runtime light/dark 
 Run:
 
 ```bash
-bunx scb validate path/to/article.mdx
-bunx scb validate path/to/article.mdx --strict
+bunx scribe validate path/to/article.mdx
+bunx scribe validate path/to/article.mdx --strict
 ```
 
-With npm, use `npx scb validate path/to/article.mdx`.
+With npm, use `npx scribe validate path/to/article.mdx`.
 
 Interpret exit codes as `0` success, `1` article validation failure, and `2` invalid CLI usage. Warnings do not fail unless strict mode requires it. Diagnostics should name the file, position when available, severity, stable code, and remediation.
 
@@ -192,10 +192,10 @@ For an established site, compare computed body font, body size, line height, par
 Use Studio for a source-authoritative local editing loop when helpful:
 
 ```bash
-bunx scb studio path/to/article.mdx --mode foundation
+bunx scribe studio path/to/article.mdx --mode foundation
 ```
 
-Studio detects the project style mode with the same rules as `scb init`; use `--mode` only as a deliberate override. Markdown mode edits source beside the production renderer. Rich Text mode is a constrained visual helper whose accepted edits serialize to the canonical Markdown draft; its Markdown mirror is read-only, and unsupported MDX remains a byte-identical protected block that must be edited in Markdown mode. Studio saves explicitly to the displayed article path, warns before closing with unwritten changes, detects external conflicts, and writes atomically. Frontmatter supplies a generated Banner when it includes a title and no explicit Banner exists. Absolute image paths resolve from the project `public` directory, and missing assets remain visible in the preview. Studio is local-only and not a WYSIWYG editor, CMS, or page builder. Use `--host-css` only for one explicit local CSS file and account for framework preprocessing limitations.
+Studio detects the project style mode with the same rules as `scribe init`; use `--mode` only as a deliberate override. Markdown mode edits source beside the production renderer. Rich Text mode is a constrained visual helper whose accepted edits serialize to the canonical Markdown draft; its Markdown mirror is read-only, and unsupported MDX remains a byte-identical protected block that must be edited in Markdown mode. Studio saves explicitly to the displayed article path, warns before closing with unwritten changes, detects external conflicts, and writes atomically. Frontmatter supplies a generated Banner when it includes a title and no explicit Banner exists. Absolute image paths resolve from the project `public` directory, and missing assets remain visible in the preview. Studio is local-only and not a WYSIWYG editor, CMS, or page builder. Use `--host-css` only for one explicit local CSS file and account for framework preprocessing limitations.
 
 ## Diagnose the boundary
 
@@ -218,5 +218,5 @@ Reduce defects to ordinary semantic content before adding CSS. Do not introduce 
 - Confirm Shiki output is static and browser bundles contain no highlighter runtime.
 - Confirm copy is the only article behavior requiring hydration.
 - Confirm host fonts, colors, radius, and theme behavior remain native.
-- Run `bunx scb validate`, strict TypeScript, and the host production build.
+- Run `bunx scribe validate`, strict TypeScript, and the host production build.
 - Visually inspect desktop and mobile output before declaring success.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -15,7 +15,7 @@ Scribe is not a hosted blogging platform, CMS, website builder, rich-text editor
 | `@scribe-sdk/react` | Publication boundary, component map, and editorial primitives | package root |
 | `@scribe-sdk/styles` | Scoped publishing mechanics and optional editorial presentation | `/foundation.css`, `/default.css`, `/tailwind.css` |
 | `@scribe-sdk/mdx` | Shared compile-time MDX configuration and validation | package root, `/next`, `/next-remote`, `/remark`, `/rehype` |
-| `@scribe-sdk/cli` | Validation, deliberate setup, and the local authoring Studio | `scb` binary |
+| `@scribe-sdk/cli` | Validation, deliberate setup, and the local authoring Studio | `scribe` binary |
 
 Each installed package includes the same canonical `SKILL.md`. Agents can discover it at `node_modules/@scribe-sdk/<package>/SKILL.md`; the repository source of truth is [`SKILL.md`](./SKILL.md).
 
@@ -35,31 +35,35 @@ npm install @scribe-sdk/react@alpha @scribe-sdk/styles@alpha @scribe-sdk/mdx@alp
 npm install --save-dev @scribe-sdk/cli@alpha
 ```
 
+Project-local CLI installation is recommended so every contributor uses the same prerelease. A user-level CLI is also supported through `bun add --global @scribe-sdk/cli@alpha` or `npm install --global @scribe-sdk/cli@alpha`; the project still owns its runtime Scribe dependencies.
+
 Package installation is inert: it does not edit source files, run project detection, or make network calls beyond normal package-manager behavior. Inspect a proposed integration explicitly:
 
 ```bash
-bunx scb init --dry-run
+bunx scribe init --dry-run
 ```
 
 With npm, run the same locally installed binary through `npx`:
 
 ```bash
-npx scb init --dry-run
+npx scribe init --dry-run
 ```
 
 ### CLI reference
 
-Run CLI commands through `bunx scb` or `npx scb` after installing `@scribe-sdk/cli` locally. The examples below use `scb` to show the command surface without repeating both runners.
+Run CLI commands through `bunx scribe` or `npx scribe` after installing `@scribe-sdk/cli` locally. The examples below use `scribe` to show the command surface without repeating both runners.
+
+`scribe` is the primary executable. The prerelease-only `scb` compatibility alias remains available with identical behavior for existing alpha users; new integrations should use `scribe`.
 
 | Command | Purpose |
 | --- | --- |
-| `scb init [--dry-run] [--mode <mode>] [--yes]` | Inspect and deliberately initialize Scribe in the current React project; mode is `foundation`, `default`, or `tailwind` |
-| `scb validate <article.mdx> [--strict]` | Compile and validate one article without executing the complete host application |
-| `scb studio <article> [--mode <mode>] [--host-css <file>] [--port <number>] [--no-open]` | Open the local, source-authoritative Markdown/MDX Studio; mode is `foundation`, `default`, or `tailwind` |
-| `scb --help` | Show the installed CLI command surface |
-| `scb --version` | Print the installed Scribe version |
+| `scribe init [--dry-run] [--mode <mode>] [--yes]` | Inspect and deliberately initialize Scribe in the current React project; mode is `foundation`, `default`, or `tailwind` |
+| `scribe validate <article.mdx> [--strict]` | Compile and validate one article without executing the complete host application |
+| `scribe studio <article> [--mode <mode>] [--host-css <file>] [--port <number>] [--no-open]` | Open the local, source-authoritative Markdown/MDX Studio; mode is `foundation`, `default`, or `tailwind` |
+| `scribe --help` | Show the installed CLI command surface |
+| `scribe --version` | Print the installed Scribe version |
 
-Use `scb init --help` or `scb studio --help` for command-specific option summaries. CLI exit codes are consistent: `0` means success, `1` means execution or article-compilation failure, and `2` means invalid usage or unresolved initialization configuration.
+Use `scribe init --help`, `scribe validate --help`, or `scribe studio --help` for focused option summaries and examples. CLI exit codes are consistent: `0` means success, `1` means execution or article-compilation failure, and `2` means invalid usage or unresolved initialization configuration.
 
 ## Choose a style mode
 
@@ -96,15 +100,15 @@ Scribe ships no fonts and does not clone Tailwind Typography. In Tailwind mode, 
 Run initialization deliberately from the host project's root after installation:
 
 ```bash
-bunx scb init --dry-run
-bunx scb init
+bunx scribe init --dry-run
+bunx scribe init
 ```
 
 With npm:
 
 ```bash
-npx scb init --dry-run
-npx scb init
+npx scribe init --dry-run
+npx scribe init
 ```
 
 `init` inspects React, Next.js or Vite, Tailwind v3/v4, Typography and `.prose`, existing MDX integrations and plugins, syntax highlighters, global CSS, component maps, and current Scribe wiring. It recommends `foundation`, `default`, or `tailwind`, reports every proposed command and file edit, and asks before mutation. Use `--mode foundation|default|tailwind` to override the recommendation or `--yes` for a reviewed non-interactive plan.
@@ -322,7 +326,7 @@ Supported metadata is explicit:
 | additions | `add="4-6"` | Marks added lines |
 | removals | `remove="2"` | Marks removed lines |
 
-Ranges are one-based, comma-separated, and inclusive. Unknown or malformed fields fail compilation. Unsupported languages warn and fall back to plaintext by default. Enable strict behavior with `createScribeMdxOptions({ strict: true })`, `createScribeNextMdxOptions({ strict: true })`, or `scb validate article.mdx --strict`.
+Ranges are one-based, comma-separated, and inclusive. Unknown or malformed fields fail compilation. Unsupported languages warn and fall back to plaintext by default. Enable strict behavior with `createScribeMdxOptions({ strict: true })`, `createScribeNextMdxOptions({ strict: true })`, or `scribe validate article.mdx --strict`.
 
 Inline backticks remain visually distinct from framed code blocks.
 
@@ -391,18 +395,18 @@ Reduced-motion preferences disable nonessential transitions. Print styles remove
 Open a source-authoritative local workspace for one Markdown or MDX file:
 
 ```bash
-bunx scb studio ./content/article.mdx
-bunx scb studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
+bunx scribe studio ./content/article.mdx
+bunx scribe studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
 ```
 
 With npm:
 
 ```bash
-npx scb studio ./content/article.mdx
-npx scb studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
+npx scribe studio ./content/article.mdx
+npx scribe studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
 ```
 
-Studio detects the project style mode using the same rules as `scb init`; pass `--mode` only to override that result deliberately. An ambiguous project exits with guidance instead of silently choosing a visual preset. Port `4317` remains the default.
+Studio detects the project style mode using the same rules as `scribe init`; pass `--mode` only to override that result deliberately. An ambiguous project exits with guidance instead of silently choosing a visual preset. Port `4317` remains the default.
 
 Studio has exactly two authoring modes. Markdown mode keeps the source editable beside the production renderer and has no formatting toolbar. Rich Text mode is a constrained visual helper for ordinary Markdown; it provides a minimal toolbar, writes accepted edits back to the canonical Markdown draft, and shows a read-only Markdown mirror by default. Its secondary pane can switch to the same production renderer. Unsupported MDX, frontmatter, HTML, JSX, expressions, and metadata-bearing code fences remain byte-identical protected blocks with an **Edit in Markdown** action. Rich Text may refuse to edit a construct; it never pretends to support one and silently rewrites the source.
 
@@ -419,34 +423,34 @@ Use `--port 4317` to select a port and `--no-open` for headless workflows. Stop 
 Validate one article through the production compiler:
 
 ```bash
-bunx scb validate ./content/article.mdx
-bunx scb validate ./content/article.mdx --strict
+bunx scribe validate ./content/article.mdx
+bunx scribe validate ./content/article.mdx --strict
 ```
 
 With npm:
 
 ```bash
-npx scb validate ./content/article.mdx
-npx scb validate ./content/article.mdx --strict
+npx scribe validate ./content/article.mdx
+npx scribe validate ./content/article.mdx --strict
 ```
 
-`scb validate` checks MDX syntax, Scribe code metadata, supported static component metadata, compile-time highlighting, and article-level diagnostics. It does not execute or validate the complete consumer application.
+`scribe validate` checks MDX syntax, Scribe code metadata, supported static component metadata, compile-time highlighting, and article-level diagnostics. It does not execute or validate the complete consumer application.
 
 - Exit `0`: validation succeeded; warnings may have been printed.
 - Exit `1`: article compilation or strict validation failed.
 - Exit `2`: command usage was invalid.
 
-Diagnostics include the file, position when available, severity, stable code, and remediation. Unsupported languages use warning `SCB1003` and plaintext fallback unless strict mode is enabled. Run `scb --help` for the complete supported CLI surface.
+Diagnostics include the file, position when available, severity, stable code, and remediation. Unsupported languages use warning `SCB1003` and plaintext fallback unless strict mode is enabled. Run `scribe --help` for the complete supported CLI surface.
 
 If rendering differs between the Vite and Next builds, confirm that both use the matching `@scribe-sdk/mdx` version and the shared helper. If a table is not scrollable, confirm that the stylesheet is imported and the article renders beneath `.scribe`. Do not add host CSS solely to conceal a Scribe defect; reduce the case and report it at <https://github.com/aetosdios27/scribe/issues>.
 
 ## Migrating from `0.1.0-alpha.2`
 
 - Existing `default.css` imports remain supported and retain the complete editorial preset.
-- Established sites that already own article typography should switch to `foundation.css` after reviewing `scb init --dry-run` and before/after computed styles.
+- Established sites that already own article typography should switch to `foundation.css` after reviewing `scribe init --dry-run` and before/after computed styles.
 - Tailwind Typography sites should use `tailwind.css` and keep their `.prose` wrapper.
 - `next-mdx-remote/rsc` integrations should replace loader-shaped configuration with `createScribeRemoteMdxOptions()` from `@scribe-sdk/mdx/next-remote`.
-- Installation performs no migration. `scb init` reports and confirms any safe edits; existing plugins and highlighters remain untouched unless the owner changes them explicitly.
+- Installation performs no migration. `scribe init` reports and confirms any safe edits; existing plugins and highlighters remain untouched unless the owner changes them explicitly.
 
 ## Responsibility boundary
 

--- a/packages/react/SKILL.md
+++ b/packages/react/SKILL.md
@@ -36,10 +36,10 @@ Expected packages are `@scribe-sdk/react`, `@scribe-sdk/styles`, `@scribe-sdk/md
 Start with the deliberate detector:
 
 ```bash
-bunx scb init --dry-run
+bunx scribe init --dry-run
 ```
 
-Review the detected stack, recommended mode, touched files, commands, ambiguities, and existing highlighter warnings. Run `bunx scb init` only after the plan is safe. Installation itself is inert.
+Review the detected stack, recommended mode, touched files, commands, ambiguities, and existing highlighter warnings. Run `bunx scribe init` only after the plan is safe. Installation itself is inert.
 
 Choose exactly one style mode:
 
@@ -177,11 +177,11 @@ Scribe supplies color-scheme-aware styles. The host owns the runtime light/dark 
 Run:
 
 ```bash
-bunx scb validate path/to/article.mdx
-bunx scb validate path/to/article.mdx --strict
+bunx scribe validate path/to/article.mdx
+bunx scribe validate path/to/article.mdx --strict
 ```
 
-With npm, use `npx scb validate path/to/article.mdx`.
+With npm, use `npx scribe validate path/to/article.mdx`.
 
 Interpret exit codes as `0` success, `1` article validation failure, and `2` invalid CLI usage. Warnings do not fail unless strict mode requires it. Diagnostics should name the file, position when available, severity, stable code, and remediation.
 
@@ -192,10 +192,10 @@ For an established site, compare computed body font, body size, line height, par
 Use Studio for a source-authoritative local editing loop when helpful:
 
 ```bash
-bunx scb studio path/to/article.mdx --mode foundation
+bunx scribe studio path/to/article.mdx --mode foundation
 ```
 
-Studio detects the project style mode with the same rules as `scb init`; use `--mode` only as a deliberate override. Markdown mode edits source beside the production renderer. Rich Text mode is a constrained visual helper whose accepted edits serialize to the canonical Markdown draft; its Markdown mirror is read-only, and unsupported MDX remains a byte-identical protected block that must be edited in Markdown mode. Studio saves explicitly to the displayed article path, warns before closing with unwritten changes, detects external conflicts, and writes atomically. Frontmatter supplies a generated Banner when it includes a title and no explicit Banner exists. Absolute image paths resolve from the project `public` directory, and missing assets remain visible in the preview. Studio is local-only and not a WYSIWYG editor, CMS, or page builder. Use `--host-css` only for one explicit local CSS file and account for framework preprocessing limitations.
+Studio detects the project style mode with the same rules as `scribe init`; use `--mode` only as a deliberate override. Markdown mode edits source beside the production renderer. Rich Text mode is a constrained visual helper whose accepted edits serialize to the canonical Markdown draft; its Markdown mirror is read-only, and unsupported MDX remains a byte-identical protected block that must be edited in Markdown mode. Studio saves explicitly to the displayed article path, warns before closing with unwritten changes, detects external conflicts, and writes atomically. Frontmatter supplies a generated Banner when it includes a title and no explicit Banner exists. Absolute image paths resolve from the project `public` directory, and missing assets remain visible in the preview. Studio is local-only and not a WYSIWYG editor, CMS, or page builder. Use `--host-css` only for one explicit local CSS file and account for framework preprocessing limitations.
 
 ## Diagnose the boundary
 
@@ -218,5 +218,5 @@ Reduce defects to ordinary semantic content before adding CSS. Do not introduce 
 - Confirm Shiki output is static and browser bundles contain no highlighter runtime.
 - Confirm copy is the only article behavior requiring hydration.
 - Confirm host fonts, colors, radius, and theme behavior remain native.
-- Run `bunx scb validate`, strict TypeScript, and the host production build.
+- Run `bunx scribe validate`, strict TypeScript, and the host production build.
 - Visually inspect desktop and mobile output before declaring success.

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -15,7 +15,7 @@ Scribe is not a hosted blogging platform, CMS, website builder, rich-text editor
 | `@scribe-sdk/react` | Publication boundary, component map, and editorial primitives | package root |
 | `@scribe-sdk/styles` | Scoped publishing mechanics and optional editorial presentation | `/foundation.css`, `/default.css`, `/tailwind.css` |
 | `@scribe-sdk/mdx` | Shared compile-time MDX configuration and validation | package root, `/next`, `/next-remote`, `/remark`, `/rehype` |
-| `@scribe-sdk/cli` | Validation, deliberate setup, and the local authoring Studio | `scb` binary |
+| `@scribe-sdk/cli` | Validation, deliberate setup, and the local authoring Studio | `scribe` binary |
 
 Each installed package includes the same canonical `SKILL.md`. Agents can discover it at `node_modules/@scribe-sdk/<package>/SKILL.md`; the repository source of truth is [`SKILL.md`](./SKILL.md).
 
@@ -35,31 +35,35 @@ npm install @scribe-sdk/react@alpha @scribe-sdk/styles@alpha @scribe-sdk/mdx@alp
 npm install --save-dev @scribe-sdk/cli@alpha
 ```
 
+Project-local CLI installation is recommended so every contributor uses the same prerelease. A user-level CLI is also supported through `bun add --global @scribe-sdk/cli@alpha` or `npm install --global @scribe-sdk/cli@alpha`; the project still owns its runtime Scribe dependencies.
+
 Package installation is inert: it does not edit source files, run project detection, or make network calls beyond normal package-manager behavior. Inspect a proposed integration explicitly:
 
 ```bash
-bunx scb init --dry-run
+bunx scribe init --dry-run
 ```
 
 With npm, run the same locally installed binary through `npx`:
 
 ```bash
-npx scb init --dry-run
+npx scribe init --dry-run
 ```
 
 ### CLI reference
 
-Run CLI commands through `bunx scb` or `npx scb` after installing `@scribe-sdk/cli` locally. The examples below use `scb` to show the command surface without repeating both runners.
+Run CLI commands through `bunx scribe` or `npx scribe` after installing `@scribe-sdk/cli` locally. The examples below use `scribe` to show the command surface without repeating both runners.
+
+`scribe` is the primary executable. The prerelease-only `scb` compatibility alias remains available with identical behavior for existing alpha users; new integrations should use `scribe`.
 
 | Command | Purpose |
 | --- | --- |
-| `scb init [--dry-run] [--mode <mode>] [--yes]` | Inspect and deliberately initialize Scribe in the current React project; mode is `foundation`, `default`, or `tailwind` |
-| `scb validate <article.mdx> [--strict]` | Compile and validate one article without executing the complete host application |
-| `scb studio <article> [--mode <mode>] [--host-css <file>] [--port <number>] [--no-open]` | Open the local, source-authoritative Markdown/MDX Studio; mode is `foundation`, `default`, or `tailwind` |
-| `scb --help` | Show the installed CLI command surface |
-| `scb --version` | Print the installed Scribe version |
+| `scribe init [--dry-run] [--mode <mode>] [--yes]` | Inspect and deliberately initialize Scribe in the current React project; mode is `foundation`, `default`, or `tailwind` |
+| `scribe validate <article.mdx> [--strict]` | Compile and validate one article without executing the complete host application |
+| `scribe studio <article> [--mode <mode>] [--host-css <file>] [--port <number>] [--no-open]` | Open the local, source-authoritative Markdown/MDX Studio; mode is `foundation`, `default`, or `tailwind` |
+| `scribe --help` | Show the installed CLI command surface |
+| `scribe --version` | Print the installed Scribe version |
 
-Use `scb init --help` or `scb studio --help` for command-specific option summaries. CLI exit codes are consistent: `0` means success, `1` means execution or article-compilation failure, and `2` means invalid usage or unresolved initialization configuration.
+Use `scribe init --help`, `scribe validate --help`, or `scribe studio --help` for focused option summaries and examples. CLI exit codes are consistent: `0` means success, `1` means execution or article-compilation failure, and `2` means invalid usage or unresolved initialization configuration.
 
 ## Choose a style mode
 
@@ -96,15 +100,15 @@ Scribe ships no fonts and does not clone Tailwind Typography. In Tailwind mode, 
 Run initialization deliberately from the host project's root after installation:
 
 ```bash
-bunx scb init --dry-run
-bunx scb init
+bunx scribe init --dry-run
+bunx scribe init
 ```
 
 With npm:
 
 ```bash
-npx scb init --dry-run
-npx scb init
+npx scribe init --dry-run
+npx scribe init
 ```
 
 `init` inspects React, Next.js or Vite, Tailwind v3/v4, Typography and `.prose`, existing MDX integrations and plugins, syntax highlighters, global CSS, component maps, and current Scribe wiring. It recommends `foundation`, `default`, or `tailwind`, reports every proposed command and file edit, and asks before mutation. Use `--mode foundation|default|tailwind` to override the recommendation or `--yes` for a reviewed non-interactive plan.
@@ -322,7 +326,7 @@ Supported metadata is explicit:
 | additions | `add="4-6"` | Marks added lines |
 | removals | `remove="2"` | Marks removed lines |
 
-Ranges are one-based, comma-separated, and inclusive. Unknown or malformed fields fail compilation. Unsupported languages warn and fall back to plaintext by default. Enable strict behavior with `createScribeMdxOptions({ strict: true })`, `createScribeNextMdxOptions({ strict: true })`, or `scb validate article.mdx --strict`.
+Ranges are one-based, comma-separated, and inclusive. Unknown or malformed fields fail compilation. Unsupported languages warn and fall back to plaintext by default. Enable strict behavior with `createScribeMdxOptions({ strict: true })`, `createScribeNextMdxOptions({ strict: true })`, or `scribe validate article.mdx --strict`.
 
 Inline backticks remain visually distinct from framed code blocks.
 
@@ -391,18 +395,18 @@ Reduced-motion preferences disable nonessential transitions. Print styles remove
 Open a source-authoritative local workspace for one Markdown or MDX file:
 
 ```bash
-bunx scb studio ./content/article.mdx
-bunx scb studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
+bunx scribe studio ./content/article.mdx
+bunx scribe studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
 ```
 
 With npm:
 
 ```bash
-npx scb studio ./content/article.mdx
-npx scb studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
+npx scribe studio ./content/article.mdx
+npx scribe studio ./content/article.mdx --mode foundation --host-css ./src/app/globals.css
 ```
 
-Studio detects the project style mode using the same rules as `scb init`; pass `--mode` only to override that result deliberately. An ambiguous project exits with guidance instead of silently choosing a visual preset. Port `4317` remains the default.
+Studio detects the project style mode using the same rules as `scribe init`; pass `--mode` only to override that result deliberately. An ambiguous project exits with guidance instead of silently choosing a visual preset. Port `4317` remains the default.
 
 Studio has exactly two authoring modes. Markdown mode keeps the source editable beside the production renderer and has no formatting toolbar. Rich Text mode is a constrained visual helper for ordinary Markdown; it provides a minimal toolbar, writes accepted edits back to the canonical Markdown draft, and shows a read-only Markdown mirror by default. Its secondary pane can switch to the same production renderer. Unsupported MDX, frontmatter, HTML, JSX, expressions, and metadata-bearing code fences remain byte-identical protected blocks with an **Edit in Markdown** action. Rich Text may refuse to edit a construct; it never pretends to support one and silently rewrites the source.
 
@@ -419,34 +423,34 @@ Use `--port 4317` to select a port and `--no-open` for headless workflows. Stop 
 Validate one article through the production compiler:
 
 ```bash
-bunx scb validate ./content/article.mdx
-bunx scb validate ./content/article.mdx --strict
+bunx scribe validate ./content/article.mdx
+bunx scribe validate ./content/article.mdx --strict
 ```
 
 With npm:
 
 ```bash
-npx scb validate ./content/article.mdx
-npx scb validate ./content/article.mdx --strict
+npx scribe validate ./content/article.mdx
+npx scribe validate ./content/article.mdx --strict
 ```
 
-`scb validate` checks MDX syntax, Scribe code metadata, supported static component metadata, compile-time highlighting, and article-level diagnostics. It does not execute or validate the complete consumer application.
+`scribe validate` checks MDX syntax, Scribe code metadata, supported static component metadata, compile-time highlighting, and article-level diagnostics. It does not execute or validate the complete consumer application.
 
 - Exit `0`: validation succeeded; warnings may have been printed.
 - Exit `1`: article compilation or strict validation failed.
 - Exit `2`: command usage was invalid.
 
-Diagnostics include the file, position when available, severity, stable code, and remediation. Unsupported languages use warning `SCB1003` and plaintext fallback unless strict mode is enabled. Run `scb --help` for the complete supported CLI surface.
+Diagnostics include the file, position when available, severity, stable code, and remediation. Unsupported languages use warning `SCB1003` and plaintext fallback unless strict mode is enabled. Run `scribe --help` for the complete supported CLI surface.
 
 If rendering differs between the Vite and Next builds, confirm that both use the matching `@scribe-sdk/mdx` version and the shared helper. If a table is not scrollable, confirm that the stylesheet is imported and the article renders beneath `.scribe`. Do not add host CSS solely to conceal a Scribe defect; reduce the case and report it at <https://github.com/aetosdios27/scribe/issues>.
 
 ## Migrating from `0.1.0-alpha.2`
 
 - Existing `default.css` imports remain supported and retain the complete editorial preset.
-- Established sites that already own article typography should switch to `foundation.css` after reviewing `scb init --dry-run` and before/after computed styles.
+- Established sites that already own article typography should switch to `foundation.css` after reviewing `scribe init --dry-run` and before/after computed styles.
 - Tailwind Typography sites should use `tailwind.css` and keep their `.prose` wrapper.
 - `next-mdx-remote/rsc` integrations should replace loader-shaped configuration with `createScribeRemoteMdxOptions()` from `@scribe-sdk/mdx/next-remote`.
-- Installation performs no migration. `scb init` reports and confirms any safe edits; existing plugins and highlighters remain untouched unless the owner changes them explicitly.
+- Installation performs no migration. `scribe init` reports and confirms any safe edits; existing plugins and highlighters remain untouched unless the owner changes them explicitly.
 
 ## Responsibility boundary
 

--- a/packages/styles/SKILL.md
+++ b/packages/styles/SKILL.md
@@ -36,10 +36,10 @@ Expected packages are `@scribe-sdk/react`, `@scribe-sdk/styles`, `@scribe-sdk/md
 Start with the deliberate detector:
 
 ```bash
-bunx scb init --dry-run
+bunx scribe init --dry-run
 ```
 
-Review the detected stack, recommended mode, touched files, commands, ambiguities, and existing highlighter warnings. Run `bunx scb init` only after the plan is safe. Installation itself is inert.
+Review the detected stack, recommended mode, touched files, commands, ambiguities, and existing highlighter warnings. Run `bunx scribe init` only after the plan is safe. Installation itself is inert.
 
 Choose exactly one style mode:
 
@@ -177,11 +177,11 @@ Scribe supplies color-scheme-aware styles. The host owns the runtime light/dark 
 Run:
 
 ```bash
-bunx scb validate path/to/article.mdx
-bunx scb validate path/to/article.mdx --strict
+bunx scribe validate path/to/article.mdx
+bunx scribe validate path/to/article.mdx --strict
 ```
 
-With npm, use `npx scb validate path/to/article.mdx`.
+With npm, use `npx scribe validate path/to/article.mdx`.
 
 Interpret exit codes as `0` success, `1` article validation failure, and `2` invalid CLI usage. Warnings do not fail unless strict mode requires it. Diagnostics should name the file, position when available, severity, stable code, and remediation.
 
@@ -192,10 +192,10 @@ For an established site, compare computed body font, body size, line height, par
 Use Studio for a source-authoritative local editing loop when helpful:
 
 ```bash
-bunx scb studio path/to/article.mdx --mode foundation
+bunx scribe studio path/to/article.mdx --mode foundation
 ```
 
-Studio detects the project style mode with the same rules as `scb init`; use `--mode` only as a deliberate override. Markdown mode edits source beside the production renderer. Rich Text mode is a constrained visual helper whose accepted edits serialize to the canonical Markdown draft; its Markdown mirror is read-only, and unsupported MDX remains a byte-identical protected block that must be edited in Markdown mode. Studio saves explicitly to the displayed article path, warns before closing with unwritten changes, detects external conflicts, and writes atomically. Frontmatter supplies a generated Banner when it includes a title and no explicit Banner exists. Absolute image paths resolve from the project `public` directory, and missing assets remain visible in the preview. Studio is local-only and not a WYSIWYG editor, CMS, or page builder. Use `--host-css` only for one explicit local CSS file and account for framework preprocessing limitations.
+Studio detects the project style mode with the same rules as `scribe init`; use `--mode` only as a deliberate override. Markdown mode edits source beside the production renderer. Rich Text mode is a constrained visual helper whose accepted edits serialize to the canonical Markdown draft; its Markdown mirror is read-only, and unsupported MDX remains a byte-identical protected block that must be edited in Markdown mode. Studio saves explicitly to the displayed article path, warns before closing with unwritten changes, detects external conflicts, and writes atomically. Frontmatter supplies a generated Banner when it includes a title and no explicit Banner exists. Absolute image paths resolve from the project `public` directory, and missing assets remain visible in the preview. Studio is local-only and not a WYSIWYG editor, CMS, or page builder. Use `--host-css` only for one explicit local CSS file and account for framework preprocessing limitations.
 
 ## Diagnose the boundary
 
@@ -218,5 +218,5 @@ Reduce defects to ordinary semantic content before adding CSS. Do not introduce 
 - Confirm Shiki output is static and browser bundles contain no highlighter runtime.
 - Confirm copy is the only article behavior requiring hydration.
 - Confirm host fonts, colors, radius, and theme behavior remain native.
-- Run `bunx scb validate`, strict TypeScript, and the host production build.
+- Run `bunx scribe validate`, strict TypeScript, and the host production build.
 - Visually inspect desktop and mobile output before declaring success.

--- a/scripts/check-release-alignment.mjs
+++ b/scripts/check-release-alignment.mjs
@@ -32,6 +32,12 @@ for (const manifest of manifests) {
   }
 }
 
+const cliManifest = manifests.find(({ name }) => name === "@scribe-sdk/cli");
+assert(
+  cliManifest?.bin?.scribe === "./dist/index.mjs" && cliManifest.bin.scb === "./dist/index.mjs",
+  "@scribe-sdk/cli must expose scribe and the scb compatibility alias from the same executable."
+);
+
 const config = JSON.parse(await readFile(join(root, ".changeset", "config.json"), "utf8"));
 assert(config.access === "public", "Changesets access must be public.");
 assert(config.baseBranch === "main", "Changesets baseBranch must be main.");

--- a/scripts/inspect-tarballs.mjs
+++ b/scripts/inspect-tarballs.mjs
@@ -39,6 +39,16 @@ for (const expected of packages) {
   if (/workspace:|file:|\/home\/|\\Users\\/u.test(manifestText)) {
     throw new Error(`${file} contains a workspace or filesystem reference.`);
   }
+  if (expected.directory === "cli") {
+    const expectedBins = { scribe: "./dist/index.mjs", scb: "./dist/index.mjs" };
+    if (JSON.stringify(manifest.bin) !== JSON.stringify(expectedBins)) {
+      throw new Error(`${file} must expose the scribe binary and scb compatibility alias from dist/index.mjs.`);
+    }
+    const executable = archiveEntries.find((entry) => entry.path === "package/dist/index.mjs");
+    if (!executable || (executable.mode & 0o111) === 0) {
+      throw new Error(`${file}:dist/index.mjs is not executable.`);
+    }
+  }
   const declarationEntries = entries.filter((entry) => entry.endsWith(".d.mts"));
   for (const entry of declarationEntries) {
     const declaration = entryText(archiveEntries, `package/${entry}`, file);
@@ -59,6 +69,7 @@ for (const expected of packages) {
     topLevelFiles,
     sourceMaps: entries.filter((entry) => entry.endsWith(".map")),
     declarations: declarationEntries,
+    bin: manifest.bin,
     files: entries
   });
 }

--- a/scripts/lib/spawn.d.mts
+++ b/scripts/lib/spawn.d.mts
@@ -1,0 +1,7 @@
+import type { SpawnSyncOptionsWithStringEncoding, SpawnSyncReturns } from "node:child_process";
+
+export function spawnPortableSync(
+  command: string,
+  args: readonly string[],
+  options: SpawnSyncOptionsWithStringEncoding
+): SpawnSyncReturns<string>;

--- a/scripts/lib/spawn.mjs
+++ b/scripts/lib/spawn.mjs
@@ -1,0 +1,5 @@
+import crossSpawn from "cross-spawn";
+
+export function spawnPortableSync(command, args, options = {}) {
+  return crossSpawn.sync(command, args, { ...options, shell: false });
+}

--- a/scripts/lib/tarball.mjs
+++ b/scripts/lib/tarball.mjs
@@ -11,6 +11,7 @@ export function readTarball(buffer) {
     const name = readString(header, 0, 100);
     const prefix = readString(header, 345, 155);
     const path = prefix ? `${prefix}/${name}` : name;
+    const mode = readOctal(header, 100, 8);
     const size = readOctal(header, 124, 12);
     const type = String.fromCharCode(header[156] || 48);
     const bodyStart = offset + 512;
@@ -19,6 +20,7 @@ export function readTarball(buffer) {
     if (bodyEnd > archive.length) throw new Error(`Invalid tarball entry ${path}: content exceeds archive size.`);
     entries.push({
       path,
+      mode,
       size,
       type,
       content: archive.subarray(bodyStart, bodyEnd)

--- a/scripts/test-packed-consumers.mjs
+++ b/scripts/test-packed-consumers.mjs
@@ -120,11 +120,15 @@ createRoot(root).render(<Article components={createScribeComponents()} />);
   run("node", ["--input-type=module", "-e", "import('@scribe-sdk/react').then((api) => { const expected = ['Banner','Callout','CodeFrame','Figure','Publication','ScribeImage','createScribeComponents']; if (JSON.stringify(Object.keys(api).sort()) !== JSON.stringify(expected)) process.exit(1) })"], directory);
   run("node", ["--input-type=module", "-e", "import('@scribe-sdk/react/components').then(() => process.exit(1)).catch((error) => { if (error.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') process.exit(1) })"], directory);
   await assertPackagedSkill(directory);
-  const cliVersion = run(bin(directory, "scb"), ["--version"], directory);
+  const cliVersion = run(bin(directory, "scribe"), ["--version"], directory);
   if (cliVersion.stdout.trim() !== version) throw new Error(`Bun Vite CLI reported ${cliVersion.stdout.trim()}, expected ${version}.`);
+  const aliasVersion = run(bin(directory, "scb"), ["--version"], directory);
+  if (aliasVersion.stdout.trim() !== version) throw new Error(`Bun Vite scb alias reported ${aliasVersion.stdout.trim()}, expected ${version}.`);
+  run(bin(directory, "scribe"), ["--help"], directory);
   run(bin(directory, "scb"), ["--help"], directory);
+  run(bin(directory, "scribe"), ["validate", join(directory, "src/article.mdx")], directory);
   run(bin(directory, "scb"), ["validate", join(directory, "src/article.mdx")], directory);
-  const invalid = run(bin(directory, "scb"), ["validate", join(directory, "src/invalid.mdx")], directory, false);
+  const invalid = run(bin(directory, "scribe"), ["validate", join(directory, "src/invalid.mdx")], directory, false);
   if (invalid.status !== 1 || !invalid.stderr.includes("SCB1101")) throw new Error("Bun Vite invalid fixture did not produce SCB1101.");
   await smokeStudio(directory, join(directory, "src/article.mdx"));
 }
@@ -190,11 +194,15 @@ export default function Layout({ children }: { children: ReactNode }) { return <
   run(executable("npm"), ["run", "build"], directory);
   run("node", ["--input-type=module", "-e", "import('@scribe-sdk/cli/dist/index.mjs').then(() => process.exit(1)).catch((error) => { if (error.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') process.exit(1) })"], directory);
   await assertPackagedSkill(directory);
-  const cliVersion = run(bin(directory, "scb"), ["--version"], directory);
+  const cliVersion = run(bin(directory, "scribe"), ["--version"], directory);
   if (cliVersion.stdout.trim() !== version) throw new Error(`npm Next CLI reported ${cliVersion.stdout.trim()}, expected ${version}.`);
+  const aliasVersion = run(bin(directory, "scb"), ["--version"], directory);
+  if (aliasVersion.stdout.trim() !== version) throw new Error(`npm Next scb alias reported ${aliasVersion.stdout.trim()}, expected ${version}.`);
+  run(bin(directory, "scribe"), ["--help"], directory);
   run(bin(directory, "scb"), ["--help"], directory);
+  run(executable("npx"), ["--no-install", "scribe", "validate", join(directory, "app/article.mdx")], directory);
   run(bin(directory, "scb"), ["validate", join(directory, "app/article.mdx")], directory);
-  const invalid = run(bin(directory, "scb"), ["validate", join(directory, "invalid.mdx")], directory, false);
+  const invalid = run(bin(directory, "scribe"), ["validate", join(directory, "invalid.mdx")], directory, false);
   if (invalid.status !== 1 || !invalid.stderr.includes("SCB1101")) throw new Error("npm Next invalid fixture did not produce SCB1101.");
 }
 
@@ -404,7 +412,7 @@ async function runStreaming(command, args, cwd) {
 
 async function smokeStudio(directory, articlePath) {
   const port = await availablePort();
-  const command = bin(directory, "scb");
+  const command = bin(directory, "scribe");
   const args = ["studio", articlePath, "--mode", "foundation", "--port", String(port), "--no-open"];
   const child = spawn(command, args, { cwd: directory, shell: requiresCommandShell(command), stdio: ["ignore", "pipe", "pipe"] });
   let stdout = "";
@@ -415,7 +423,7 @@ async function smokeStudio(directory, articlePath) {
   try {
     await waitFor(async () => {
       if (child.exitCode !== null) throw new Error(`Packed Studio exited early:\n${stdout}\n${stderr}`);
-      if (!stdout.includes("Scribe Studio:")) return false;
+      if (!stdout.includes("Scribe Studio")) return false;
       const response = await fetch(`http://127.0.0.1:${port}/__scribe/api/document`).catch(() => undefined);
       return response?.ok === true;
     }, 15_000);

--- a/scripts/test-portable-cli.mjs
+++ b/scripts/test-portable-cli.mjs
@@ -3,7 +3,7 @@ import { access, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:
 import { tmpdir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 
-import { executable } from "./lib/platform.mjs";
+import { executable, requiresCommandShell } from "./lib/platform.mjs";
 
 const root = process.cwd();
 const release = join(root, ".scribe-release");
@@ -100,10 +100,11 @@ function run(command, args, cwd, requireSuccess = true, env = {}) {
   const result = spawnSync(command, args, {
     cwd,
     encoding: "utf8",
+    shell: requiresCommandShell(command),
     env: { ...process.env, PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1", ...env }
   });
-  results.push({ command: [command, ...args].join(" "), status: result.status, stdout: result.stdout.trim(), stderr: result.stderr.trim() });
   if (result.error) throw result.error;
+  results.push({ command: [command, ...args].join(" "), status: result.status, stdout: result.stdout.trim(), stderr: result.stderr.trim() });
   if (requireSuccess && result.status !== 0) {
     throw new Error(`${command} ${args.join(" ")} failed with ${result.status}:\n${result.stdout}\n${result.stderr}`);
   }

--- a/scripts/test-portable-cli.mjs
+++ b/scripts/test-portable-cli.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 
@@ -29,6 +29,7 @@ try {
     name: "scribe-portability-smoke",
     private: true,
     type: "module",
+    scripts: { "scribe:version": "scribe --version" },
     dependencies: { ...dependencies, react: "19.2.7", vite: "8.1.3" },
     overrides: dependencies
   }, null, 2));
@@ -43,21 +44,30 @@ try {
   run(executable("bun"), ["install"], directory);
   run(executable("bun"), ["install", "--frozen-lockfile"], directory);
 
-  const reportedVersion = runCli(["--version"]).stdout.trim();
-  assert(reportedVersion === version, `scb reported ${reportedVersion}; expected ${version}.`);
-  runCli(["--help"]);
-  runCli(["init", "--help"]);
-  runCli(["studio", "--help"]);
+  for (const command of ["scribe", "scb"]) {
+    const reportedVersion = runCli(command, ["--version"]).stdout.trim();
+    assert(reportedVersion === version, `${command} reported ${reportedVersion}; expected ${version}.`);
+    runCli(command, ["--help"]);
+    runCli(command, ["validate", "--help"]);
+  }
+  runCli("scribe", ["init", "--help"]);
+  runCli("scribe", ["studio", "--help"]);
+  run(executable("bun"), ["run", "scribe:version"], directory);
+  run(executable("npx"), ["--no-install", "scribe", "--version"], directory);
   const beforeInit = await readFile(globalStyle, "utf8");
-  const dryRun = runCli(["init", "--dry-run"]);
-  assert(dryRun.stdout.includes("Recommended style mode: default"), "Init dry run did not recommend default mode for the raw Vite fixture.");
+  const dryRun = runCli("scribe", ["init", "--dry-run"]);
+  assert(dryRun.stdout.includes("Recommendation") && dryRun.stdout.includes("Mode    default"), "Init dry run did not recommend default mode for the raw Vite fixture.");
   assert(await readFile(globalStyle, "utf8") === beforeInit, "Init dry run modified the fixture.");
-  const usage = runCli([], false);
-  assert(usage.status === 2, `scb without arguments exited ${usage.status}; expected 2.`);
+  const usage = runCli("scribe", [], false);
+  assert(usage.status === 2, `scribe without arguments exited ${usage.status}; expected 2.`);
 
-  runCli(["validate", relative(directory, valid)]);
-  runCli(["validate", resolve(valid)]);
-  const rejected = runCli(["validate", relative(directory, invalid)], false);
+  const validResult = runCli("scribe", ["validate", relative(directory, valid)]);
+  assert(!/\u001B\[/u.test(`${validResult.stdout}${validResult.stderr}`), "Captured CLI output contained ANSI styling.");
+  runCli("scribe", ["validate", resolve(valid)]);
+  runCli("scb", ["validate", relative(directory, valid)]);
+  const noColor = runCli("scribe", ["validate", relative(directory, valid)], true, { NO_COLOR: "1" });
+  assert(!/\u001B\[/u.test(`${noColor.stdout}${noColor.stderr}`), "NO_COLOR output contained ANSI styling.");
+  const rejected = runCli("scribe", ["validate", relative(directory, invalid)], false);
   assert(rejected.status === 1, `Invalid article exited ${rejected.status}; expected 1.`);
   assert(rejected.stderr.includes("SCB1101"), "Invalid article did not report SCB1101.");
   assert(!/\n\s+at\s/u.test(rejected.stderr), "Invalid article exposed an internal stack trace.");
@@ -66,6 +76,8 @@ try {
     const installed = JSON.parse(await readFile(join(directory, "node_modules", "@scribe-sdk", name, "package.json"), "utf8"));
     assert(installed.version === version, `@scribe-sdk/${name} installed at ${installed.version}; expected ${version}.`);
   }
+
+  await verifyGlobalInstalls();
 } finally {
   await mkdir(release, { recursive: true });
   await writeFile(join(release, `portability-${process.platform}.json`), `${JSON.stringify({
@@ -80,15 +92,15 @@ try {
 
 process.stdout.write(`Packed CLI portability smoke passed on ${process.platform} for ${version}.\n`);
 
-function runCli(args, requireSuccess = true) {
-  return run(executable("bun"), ["x", "--bun", "scb", ...args], directory, requireSuccess);
+function runCli(command, args, requireSuccess = true, env = {}) {
+  return run(executable("bun"), ["x", "--bun", command, ...args], directory, requireSuccess, env);
 }
 
-function run(command, args, cwd, requireSuccess = true) {
+function run(command, args, cwd, requireSuccess = true, env = {}) {
   const result = spawnSync(command, args, {
     cwd,
     encoding: "utf8",
-    env: { ...process.env, PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1" }
+    env: { ...process.env, PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1", ...env }
   });
   results.push({ command: [command, ...args].join(" "), status: result.status, stdout: result.stdout.trim(), stderr: result.stderr.trim() });
   if (result.error) throw result.error;
@@ -96,6 +108,44 @@ function run(command, args, cwd, requireSuccess = true) {
     throw new Error(`${command} ${args.join(" ")} failed with ${result.status}:\n${result.stdout}\n${result.stderr}`);
   }
   return result;
+}
+
+async function verifyGlobalInstalls() {
+  const packageTarballs = ["mdx", "react", "styles", "cli"]
+    .map((name) => join(tarballDirectory, `scribe-sdk-${name}-${version}.tgz`));
+
+  const npmPrefix = join(directory, "npm-global");
+  run(executable("npm"), ["install", "--global", "--prefix", npmPrefix, "--no-audit", "--no-fund", ...packageTarballs], directory);
+  const npmScribe = await findExecutable(process.platform === "win32" ? npmPrefix : join(npmPrefix, "bin"), "scribe");
+  const npmVersion = run(npmScribe, ["--version"], directory).stdout.trim();
+  assert(npmVersion === version, `Global npm scribe reported ${npmVersion}; expected ${version}.`);
+  const npmAlias = await findExecutable(process.platform === "win32" ? npmPrefix : join(npmPrefix, "bin"), "scb");
+  assert(run(npmAlias, ["--version"], directory).stdout.trim() === version, "Global npm scb alias reported a different version.");
+
+  const bunHome = join(directory, "bun-global");
+  const bunEnv = { BUN_INSTALL: bunHome };
+  run(executable("bun"), ["add", "--global", ...packageTarballs], directory, true, bunEnv);
+  const bunBinDirectory = run(executable("bun"), ["pm", "bin", "-g"], directory, true, bunEnv).stdout.trim();
+  const bunScribe = await findExecutable(bunBinDirectory, "scribe");
+  const bunVersion = run(bunScribe, ["--version"], directory, true, bunEnv).stdout.trim();
+  assert(bunVersion === version, `Global Bun scribe reported ${bunVersion}; expected ${version}.`);
+  const bunAlias = await findExecutable(bunBinDirectory, "scb");
+  assert(run(bunAlias, ["--version"], directory, true, bunEnv).stdout.trim() === version, "Global Bun scb alias reported a different version.");
+}
+
+async function findExecutable(directory, name) {
+  for (const candidate of process.platform === "win32"
+    ? [`${name}.exe`, `${name}.cmd`, name]
+    : [name]) {
+    const path = join(directory, candidate);
+    try {
+      await access(path);
+      return path;
+    } catch {
+      // Continue through platform shims.
+    }
+  }
+  throw new Error(`Could not find ${name} in ${directory}.`);
 }
 
 async function write(path, content) {

--- a/scripts/test-portable-cli.mjs
+++ b/scripts/test-portable-cli.mjs
@@ -1,9 +1,9 @@
-import { spawnSync } from "node:child_process";
 import { access, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 
-import { executable, requiresCommandShell } from "./lib/platform.mjs";
+import { executable } from "./lib/platform.mjs";
+import { spawnPortableSync } from "./lib/spawn.mjs";
 
 const root = process.cwd();
 const release = join(root, ".scribe-release");
@@ -97,10 +97,9 @@ function runCli(command, args, requireSuccess = true, env = {}) {
 }
 
 function run(command, args, cwd, requireSuccess = true, env = {}) {
-  const result = spawnSync(command, args, {
+  const result = spawnPortableSync(command, args, {
     cwd,
     encoding: "utf8",
-    shell: requiresCommandShell(command),
     env: { ...process.env, PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1", ...env }
   });
   if (result.error) throw result.error;

--- a/scripts/test-portable-cli.mjs
+++ b/scripts/test-portable-cli.mjs
@@ -53,7 +53,6 @@ try {
   runCli("scribe", ["init", "--help"]);
   runCli("scribe", ["studio", "--help"]);
   run(executable("bun"), ["run", "scribe:version"], directory);
-  run(executable("npx"), ["--no-install", "scribe", "--version"], directory);
   const beforeInit = await readFile(globalStyle, "utf8");
   const dryRun = runCli("scribe", ["init", "--dry-run"]);
   assert(dryRun.stdout.includes("Recommendation") && dryRun.stdout.includes("Mode    default"), "Init dry run did not recommend default mode for the raw Vite fixture.");
@@ -77,6 +76,7 @@ try {
     assert(installed.version === version, `@scribe-sdk/${name} installed at ${installed.version}; expected ${version}.`);
   }
 
+  await verifyLocalNpmInstall();
   await verifyGlobalInstalls();
 } finally {
   await mkdir(release, { recursive: true });
@@ -109,6 +109,28 @@ function run(command, args, cwd, requireSuccess = true, env = {}) {
     throw new Error(`${command} ${args.join(" ")} failed with ${result.status}:\n${result.stdout}\n${result.stderr}`);
   }
   return result;
+}
+
+async function verifyLocalNpmInstall() {
+  const npmDirectory = join(directory, "npm-local");
+  await mkdir(npmDirectory, { recursive: true });
+  await write(join(npmDirectory, "package.json"), JSON.stringify({
+    name: "scribe-portability-npm-smoke",
+    private: true,
+    dependencies: {
+      "@scribe-sdk/cli": "file:../tarballs/scribe-sdk-cli-" + version + ".tgz",
+      "@scribe-sdk/mdx": "file:../tarballs/scribe-sdk-mdx-" + version + ".tgz",
+      "@scribe-sdk/react": "file:../tarballs/scribe-sdk-react-" + version + ".tgz",
+      "@scribe-sdk/styles": "file:../tarballs/scribe-sdk-styles-" + version + ".tgz",
+      react: "19.2.7",
+      "react-dom": "19.2.7"
+    },
+    overrides: { "js-yaml": "4.3.0" }
+  }, null, 2));
+  run(executable("npm"), ["install", "--no-audit", "--no-fund"], npmDirectory);
+  const npmVersion = run(executable("npx"), ["--no-install", "scribe", "--version"], npmDirectory).stdout.trim();
+  assert(npmVersion === version, `Local npm scribe reported ${npmVersion}; expected ${version}.`);
+  assert(run(executable("npx"), ["--no-install", "scb", "--version"], npmDirectory).stdout.trim() === version, "Local npm scb alias reported a different version.");
 }
 
 async function verifyGlobalInstalls() {

--- a/tests/release/documentation.test.ts
+++ b/tests/release/documentation.test.ts
@@ -16,16 +16,20 @@ describe("release documentation", () => {
     expect(readme).toContain("The public alpha is tested against React 19.2.7, Next.js 16.2.10, Vite 8.1.3, and MDX 3.1.1.");
     expect(readme).not.toContain("beta");
     expect(readme).toContain("bun add @scribe-sdk/react@alpha @scribe-sdk/styles@alpha @scribe-sdk/mdx@alpha");
+    expect(readme).toContain("bun add --global @scribe-sdk/cli@alpha");
+    expect(readme).toContain("npm install --global @scribe-sdk/cli@alpha");
     expect(readme).toContain('import "@scribe-sdk/styles/default.css"');
     expect(readme).toContain("createScribeNextMdxOptions");
     expect(readme).toContain("createScribeComponents");
-    expect(readme).toContain("scb validate");
+    expect(readme).toContain("scribe validate");
     expect(readme).toContain("SKILL.md");
     expect(readme).toContain("Licensed under Apache-2.0");
     expect(readme).toContain("https://github.com/aetosdios27/scribe/blob/main/examples/starter-article.mdx");
     expect(readme).toContain("https://github.com/aetosdios27/scribe/blob/main/examples/starter-diagram.svg");
     expect(readme).toContain("return <Publication>{children}</Publication>");
-    expect(readme).toContain("npx scb validate ./content/article.mdx --strict");
+    expect(readme).toContain("npx scribe validate ./content/article.mdx --strict");
+    expect(readme).toContain("`scb` compatibility alias");
+    expect(readme.match(/\bscb\b/gu)).toHaveLength(1);
     expect(readme).toContain("`0 1.25rem 3rem color-mix(in oklab, #000 12%, transparent)`");
   });
 
@@ -48,10 +52,11 @@ describe("release documentation", () => {
     expect(skill).toContain("Preserve the host’s existing MDX options and plugins.");
     expect(skill).toContain("Do not create a second MDX compilation pipeline.");
     expect(skill).toContain("Do not wrap an MDX article in a second `Publication`; the Scribe MDX component map already supplies the article boundary.");
-    expect(skill).toContain("bunx scb validate path/to/article.mdx");
-    expect(skill).toContain("bunx scb validate path/to/article.mdx --strict");
-    expect(skill).toContain("npx scb validate path/to/article.mdx");
-    expect(skill).not.toMatch(/^scb validate /mu);
+    expect(skill).toContain("bunx scribe validate path/to/article.mdx");
+    expect(skill).toContain("bunx scribe validate path/to/article.mdx --strict");
+    expect(skill).toContain("npx scribe validate path/to/article.mdx");
+    expect(skill).not.toMatch(/^scribe validate /mu);
+    expect(skill).not.toMatch(/\bscb\b/u);
     expect(skill.trim().split(/\s+/u).length).toBeGreaterThan(500);
     expect(skill.trim().split(/\s+/u).length).toBeLessThan(2_500);
     expect(skill.split("\n").length).toBeLessThan(500);

--- a/tests/release/package-manifests.test.ts
+++ b/tests/release/package-manifests.test.ts
@@ -14,10 +14,14 @@ const packageFiles = {
 } as const;
 
 describe("publishable package manifests", () => {
-  it("pins the audited PostCSS override for workspace framework fixtures", async () => {
+  it("pins audited dependency overrides for workspace and consumer fixtures", async () => {
     const manifest = await readJson(join(root, "package.json"));
 
-    expect(manifest.overrides).toEqual({ "@types/mdx": "2.0.14", postcss: "8.5.19" });
+    expect(manifest.overrides).toEqual({
+      "@types/mdx": "2.0.14",
+      "js-yaml": "4.3.0",
+      postcss: "8.5.19"
+    });
   });
 
   it.each(packageNames)("hardens @scribe-sdk/%s for npm publication", async (directory) => {

--- a/tests/release/package-manifests.test.ts
+++ b/tests/release/package-manifests.test.ts
@@ -98,7 +98,7 @@ describe("publishable package manifests", () => {
 
   it("publishes the CLI as a binary rather than a library API", async () => {
     const manifest = await readJson(join(root, "packages/cli/package.json"));
-    expect(manifest.bin).toEqual({ scb: "./dist/index.mjs" });
+    expect(manifest.bin).toEqual({ scribe: "./dist/index.mjs", scb: "./dist/index.mjs" });
     expect(manifest.exports).toEqual({});
     expect(manifest.dependencies).toEqual({
       "@base-ui/react": "1.6.0",

--- a/tests/release/portability-scripts.test.ts
+++ b/tests/release/portability-scripts.test.ts
@@ -42,6 +42,16 @@ describe("cross-platform release scripts", () => {
     expect(smoke).toContain("rejected.status === 1");
   });
 
+  it("runs Windows command shims through a shell and preserves spawn errors", async () => {
+    const smoke = await source("scripts/test-portable-cli.mjs");
+
+    expect(smoke).toContain("requiresCommandShell");
+    expect(smoke).toContain("shell: requiresCommandShell(command)");
+    expect(smoke.indexOf("if (result.error) throw result.error")).toBeLessThan(
+      smoke.indexOf("results.push")
+    );
+  });
+
   it("keeps missing Helium optional for contributors but fatal for release verification", async () => {
     const wrapper = await source("scripts/run-helium-visual.mjs");
     expect(wrapper).toContain('process.argv.includes("--require-helium")');

--- a/tests/release/portability-scripts.test.ts
+++ b/tests/release/portability-scripts.test.ts
@@ -52,6 +52,14 @@ describe("cross-platform release scripts", () => {
     );
   });
 
+  it("tests npx from an npm-installed consumer instead of Bun's executable shims", async () => {
+    const smoke = await source("scripts/test-portable-cli.mjs");
+
+    expect(smoke).toContain("verifyLocalNpmInstall");
+    expect(smoke).toContain('["--no-install", "scribe", "--version"]');
+    expect(smoke).not.toContain('run(executable("npx"), ["--no-install", "scribe", "--version"], directory)');
+  });
+
   it("keeps missing Helium optional for contributors but fatal for release verification", async () => {
     const wrapper = await source("scripts/run-helium-visual.mjs");
     expect(wrapper).toContain('process.argv.includes("--require-helium")');

--- a/tests/release/portability-scripts.test.ts
+++ b/tests/release/portability-scripts.test.ts
@@ -42,11 +42,11 @@ describe("cross-platform release scripts", () => {
     expect(smoke).toContain("rejected.status === 1");
   });
 
-  it("runs Windows command shims through a shell and preserves spawn errors", async () => {
+  it("runs Windows command shims with argument-safe portable spawning and preserves spawn errors", async () => {
     const smoke = await source("scripts/test-portable-cli.mjs");
 
-    expect(smoke).toContain("requiresCommandShell");
-    expect(smoke).toContain("shell: requiresCommandShell(command)");
+    expect(smoke).toContain("spawnPortableSync");
+    expect(smoke).not.toContain("shell: requiresCommandShell(command)");
     expect(smoke.indexOf("if (result.error) throw result.error")).toBeLessThan(
       smoke.indexOf("results.push")
     );

--- a/tests/release/spawn.test.ts
+++ b/tests/release/spawn.test.ts
@@ -1,0 +1,33 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { spawnPortableSync } from "../../scripts/lib/spawn.mjs";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) =>
+    rm(directory, { recursive: true, force: true })
+  ));
+});
+
+describe("portable command spawning", () => {
+  it("preserves arguments containing spaces without a shell", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "scribe spawn "));
+    temporaryDirectories.push(directory);
+
+    const value = join(directory, "nested path");
+    const result = spawnPortableSync(
+      process.execPath,
+      ["-e", "process.stdout.write(process.argv[1])", value],
+      { encoding: "utf8" }
+    );
+
+    expect(result.error).toBeNull();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe(value);
+  });
+});


### PR DESCRIPTION
## Linear

Fixes AET-18

## Summary

- publish `scribe` as the primary executable while retaining `scb` as a silent prerelease compatibility alias
- add focused command help, typo suggestions, project-relative diagnostics, shell-safe remediation, and restrained TTY-aware status output
- structure init detection, recommendation, warnings, changes, manual steps, and next actions
- promote `scribe` through the canonical README, packaged SKILL, release procedure, and consumer checks
- verify both binaries and executable permissions in packed tarballs, local runners, `bunx`, `npx`, and isolated global installs

## Verification

- [x] Focused and full tests pass (119 tests)
- [x] Type checking passes
- [x] Meaningful consumer-facing changes include a Changeset
- [x] Documentation is updated and synchronized
- [x] Existing coverage was not weakened or skipped
- [x] Public packages build, pack, and pass tarball inspection
- [x] Linux packed portability and packed Vite/Studio consumer pass

## Visual evidence

Not applicable. This changes terminal output and package distribution, not rendered Studio or article UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `scribe` as the primary CLI command while preserving `scb` as a compatibility alias.
  * Improved command help, typo suggestions, validation guidance, and project-relative diagnostics.
  * Added structured initialization and validation output with clearer warnings, next steps, and rollback guidance.
  * Standardized color handling for interactive, captured, and `NO_COLOR` output.

* **Documentation**
  * Updated CLI examples and integration guides to use `scribe` consistently.

* **Bug Fixes**
  * Improved behavior for invalid commands and options, symlinked entry points, and ANSI-free output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->