### PR TITLE
docs: freeze the verified compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,17 @@ If rendering differs between the Vite and Next builds, confirm that both use the
 
 Scribe owns publication structure, semantic component mappings, responsive article behavior, compile-time highlighting, controls, accessibility mechanics, print behavior, and article diagnostics. The host owns typography, density, colors, visual identity, routing, page metadata, deployment, analytics, content storage, runtime theme switching, and framework-specific image optimization.
 
+## Verified compatibility
+
+The current public-alpha matrix uses fresh packed tarballs for installation, strict typechecking, and production-build claims:
+
+- Framework integrations: React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.10, `@next/mdx` 16.2.10, and `next-mdx-remote` 6.0.0.
+- Declarations: TypeScript 7.0.2 and 6.0.2 with `skipLibCheck: false`.
+- Package and CLI portability: Linux, Windows, and macOS using Bun 1.3.13 and an npm-compatible install flow.
+- Browser behavior: current Playwright-managed Chromium and Firefox, including console errors, uncaught page errors, host isolation, and narrow-viewport overflow.
+
+WebKit and Safari are not verified for this prerelease. These are tested configurations, not a claim that other modern versions cannot work. Package tarballs prove installation and production-build boundaries; the browser suites exercise the same built package output through repository integration fixtures. Host fonts may rasterize differently across operating systems, so Scribe verifies structure and behavior rather than identical glyph pixels.
+
 Scribe is in public alpha. The API may evolve before a stable release, and framework support remains intentionally narrow while real integrations validate the product.
 
 ## License

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -456,6 +456,17 @@ If rendering differs between the Vite and Next builds, confirm that both use the
 
 Scribe owns publication structure, semantic component mappings, responsive article behavior, compile-time highlighting, controls, accessibility mechanics, print behavior, and article diagnostics. The host owns typography, density, colors, visual identity, routing, page metadata, deployment, analytics, content storage, runtime theme switching, and framework-specific image optimization.
 
+## Verified compatibility
+
+The current public-alpha matrix uses fresh packed tarballs for installation, strict typechecking, and production-build claims:
+
+- Framework integrations: React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.10, `@next/mdx` 16.2.10, and `next-mdx-remote` 6.0.0.
+- Declarations: TypeScript 7.0.2 and 6.0.2 with `skipLibCheck: false`.
+- Package and CLI portability: Linux, Windows, and macOS using Bun 1.3.13 and an npm-compatible install flow.
+- Browser behavior: current Playwright-managed Chromium and Firefox, including console errors, uncaught page errors, host isolation, and narrow-viewport overflow.
+
+WebKit and Safari are not verified for this prerelease. These are tested configurations, not a claim that other modern versions cannot work. Package tarballs prove installation and production-build boundaries; the browser suites exercise the same built package output through repository integration fixtures. Host fonts may rasterize differently across operating systems, so Scribe verifies structure and behavior rather than identical glyph pixels.
+
 Scribe is in public alpha. The API may evolve before a stable release, and framework support remains intentionally narrow while real integrations validate the product.
 
 ## License

--- a/packages/mdx/README.md
+++ b/packages/mdx/README.md
@@ -456,6 +456,17 @@ If rendering differs between the Vite and Next builds, confirm that both use the
 
 Scribe owns publication structure, semantic component mappings, responsive article behavior, compile-time highlighting, controls, accessibility mechanics, print behavior, and article diagnostics. The host owns typography, density, colors, visual identity, routing, page metadata, deployment, analytics, content storage, runtime theme switching, and framework-specific image optimization.
 
+## Verified compatibility
+
+The current public-alpha matrix uses fresh packed tarballs for installation, strict typechecking, and production-build claims:
+
+- Framework integrations: React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.10, `@next/mdx` 16.2.10, and `next-mdx-remote` 6.0.0.
+- Declarations: TypeScript 7.0.2 and 6.0.2 with `skipLibCheck: false`.
+- Package and CLI portability: Linux, Windows, and macOS using Bun 1.3.13 and an npm-compatible install flow.
+- Browser behavior: current Playwright-managed Chromium and Firefox, including console errors, uncaught page errors, host isolation, and narrow-viewport overflow.
+
+WebKit and Safari are not verified for this prerelease. These are tested configurations, not a claim that other modern versions cannot work. Package tarballs prove installation and production-build boundaries; the browser suites exercise the same built package output through repository integration fixtures. Host fonts may rasterize differently across operating systems, so Scribe verifies structure and behavior rather than identical glyph pixels.
+
 Scribe is in public alpha. The API may evolve before a stable release, and framework support remains intentionally narrow while real integrations validate the product.
 
 ## License

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -456,6 +456,17 @@ If rendering differs between the Vite and Next builds, confirm that both use the
 
 Scribe owns publication structure, semantic component mappings, responsive article behavior, compile-time highlighting, controls, accessibility mechanics, print behavior, and article diagnostics. The host owns typography, density, colors, visual identity, routing, page metadata, deployment, analytics, content storage, runtime theme switching, and framework-specific image optimization.
 
+## Verified compatibility
+
+The current public-alpha matrix uses fresh packed tarballs for installation, strict typechecking, and production-build claims:
+
+- Framework integrations: React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.10, `@next/mdx` 16.2.10, and `next-mdx-remote` 6.0.0.
+- Declarations: TypeScript 7.0.2 and 6.0.2 with `skipLibCheck: false`.
+- Package and CLI portability: Linux, Windows, and macOS using Bun 1.3.13 and an npm-compatible install flow.
+- Browser behavior: current Playwright-managed Chromium and Firefox, including console errors, uncaught page errors, host isolation, and narrow-viewport overflow.
+
+WebKit and Safari are not verified for this prerelease. These are tested configurations, not a claim that other modern versions cannot work. Package tarballs prove installation and production-build boundaries; the browser suites exercise the same built package output through repository integration fixtures. Host fonts may rasterize differently across operating systems, so Scribe verifies structure and behavior rather than identical glyph pixels.
+
 Scribe is in public alpha. The API may evolve before a stable release, and framework support remains intentionally narrow while real integrations validate the product.
 
 ## License

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -456,6 +456,17 @@ If rendering differs between the Vite and Next builds, confirm that both use the
 
 Scribe owns publication structure, semantic component mappings, responsive article behavior, compile-time highlighting, controls, accessibility mechanics, print behavior, and article diagnostics. The host owns typography, density, colors, visual identity, routing, page metadata, deployment, analytics, content storage, runtime theme switching, and framework-specific image optimization.
 
+## Verified compatibility
+
+The current public-alpha matrix uses fresh packed tarballs for installation, strict typechecking, and production-build claims:
+
+- Framework integrations: React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.10, `@next/mdx` 16.2.10, and `next-mdx-remote` 6.0.0.
+- Declarations: TypeScript 7.0.2 and 6.0.2 with `skipLibCheck: false`.
+- Package and CLI portability: Linux, Windows, and macOS using Bun 1.3.13 and an npm-compatible install flow.
+- Browser behavior: current Playwright-managed Chromium and Firefox, including console errors, uncaught page errors, host isolation, and narrow-viewport overflow.
+
+WebKit and Safari are not verified for this prerelease. These are tested configurations, not a claim that other modern versions cannot work. Package tarballs prove installation and production-build boundaries; the browser suites exercise the same built package output through repository integration fixtures. Host fonts may rasterize differently across operating systems, so Scribe verifies structure and behavior rather than identical glyph pixels.
+
 Scribe is in public alpha. The API may evolve before a stable release, and framework support remains intentionally narrow while real integrations validate the product.
 
 ## License

--- a/tests/release/documentation.test.ts
+++ b/tests/release/documentation.test.ts
@@ -33,6 +33,21 @@ describe("release documentation", () => {
     expect(readme).toContain("`0 1.25rem 3rem color-mix(in oklab, #000 12%, transparent)`");
   });
 
+  it("freezes compatibility claims to the verified public-alpha matrix", async () => {
+    const readme = await readFile(join(root, "README.md"), "utf8");
+
+    expect(readme).toContain("## Verified compatibility");
+    expect(readme).toContain("React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.10, `@next/mdx` 16.2.10, and `next-mdx-remote` 6.0.0");
+    expect(readme).toContain("TypeScript 7.0.2 and 6.0.2 with `skipLibCheck: false`");
+    expect(readme).toContain("Linux, Windows, and macOS using Bun 1.3.13 and an npm-compatible install flow");
+    expect(readme).toContain("Playwright-managed Chromium and Firefox");
+    expect(readme).toContain("WebKit and Safari are not verified for this prerelease");
+    expect(readme).toContain("These are tested configurations, not a claim that other modern versions cannot work.");
+    expect(readme).toContain("MDX is executable local project content; open only files you trust.");
+    expect(readme).toContain("Rich Text mode is a constrained visual helper for ordinary Markdown");
+    expect(readme).toContain("Non-inherited element rules do not cross a CSS Module boundary automatically");
+  });
+
   it("keeps every packaged skill and README generated from the canonical files", async () => {
     const canonicalReadme = await readFile(join(root, "README.md"), "utf8");
     const canonicalSkill = await readFile(join(root, "SKILL.md"), "utf8");


### PR DESCRIPTION
## Linear

Fixes AET-19

## Summary

- record the exact packed-package framework, TypeScript, package-manager, OS, and browser evidence
- distinguish tested configurations from broader compatibility
- freeze Studio trust/Rich Text and scoped-style preservation boundaries in release tests
- synchronize the canonical README into every published package

## Verification

- [x] Focused tests pass
- [x] Type checking passes
- [x] No Changeset is required because this freezes existing evidence without changing consumer behavior
- [x] Documentation is updated
- [x] Existing coverage was not weakened or skipped

Local: 123 Vitest tests, TypeScript 7/6, package build/pack/inspection, packed Bun/Vite consumer, production audit, documentation and release checks. Hosted CI is authoritative for the complete npm/Next, OS, Chromium, and Firefox matrix.

## Visual evidence

Not applicable — documentation and release assertions only.