### PR TITLE
fix(studio): harden draft durability and recovery

### DIFF
--- a/.changeset/durable-studios-recover.md
+++ b/.changeset/durable-studios-recover.md
@@ -1,0 +1,5 @@
+---
+"@scribe-sdk/cli": patch
+---
+
+Protect Scribe Studio drafts with durable local recovery, serialized single-writer mutations, conflict-aware atomic saves, symlink-safe source handling, isolated compiler work, and live preview updates that do not reload the preview document.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Scan browser bundles
         run: bun run release:bundle-scan
       - name: Audit production dependencies
-        run: bun audit --production
+        run: bun run release:audit
       - name: Check repository whitespace
         run: git diff --check
       - name: Confirm verification leaves tracked files unchanged

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Scribe is an open-source publishing SDK that turns ordinary Markdown, MDX, seman
 
 Scribe is for developers who already own a React website built with Next.js or Vite and want publication-grade typography, code, tables, banners, callouts, figures, responsive behavior, and accessibility without assembling a publishing design system themselves. It transforms semantic article content at build time and renders it through a small React component map plus scoped CSS.
 
-Scribe is not a hosted blogging platform, CMS, website builder, rich-text editor, proprietary content format, collaboration service, or replacement for React, Next.js, MDX, routing, deployment, analytics, or content storage. The public alpha is tested against React 19.2.7, Next.js 16.2.10, Vite 8.1.3, and MDX 3.1.1. Broader compatibility will be validated through real integrations.
+Scribe is not a hosted blogging platform, CMS, website builder, rich-text editor, proprietary content format, collaboration service, or replacement for React, Next.js, MDX, routing, deployment, analytics, or content storage. The public alpha is tested against React 19.2.7, Next.js 16.2.11, Vite 8.1.3, and MDX 3.1.1. Broader compatibility will be validated through real integrations.
 
 ## Packages
 
@@ -117,10 +117,10 @@ Initialization is minimal and idempotent. It does not replace existing remark/re
 
 ## Next.js MDX integration
 
-The tested Next.js path uses Next 16.2.10 and React 19.2.7. Install Next’s MDX integration if the host does not already have it:
+The tested Next.js path uses Next 16.2.11 and React 19.2.7. Install Next’s MDX integration if the host does not already have it:
 
 ```bash
-bun add @next/mdx@16.2.10 @mdx-js/loader@3.1.1 @mdx-js/react@3.1.1
+bun add @next/mdx@16.2.11 @mdx-js/loader@3.1.1 @mdx-js/react@3.1.1
 ```
 
 Configure the shared Scribe compiler in `next.config.mjs`:
@@ -460,7 +460,7 @@ Scribe owns publication structure, semantic component mappings, responsive artic
 
 The current public-alpha matrix uses fresh packed tarballs for installation, strict typechecking, and production-build claims:
 
-- Framework integrations: React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.10, `@next/mdx` 16.2.10, and `next-mdx-remote` 6.0.0.
+- Framework integrations: React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.11, `@next/mdx` 16.2.11, and `next-mdx-remote` 6.0.0.
 - Declarations: TypeScript 7.0.2 and 6.0.2 with `skipLibCheck: false`.
 - Package and CLI portability: Linux, Windows, and macOS using Bun 1.3.13 and an npm-compatible install flow.
 - Browser behavior: current Playwright-managed Chromium and Firefox, including console errors, uncaught page errors, host isolation, and narrow-viewport overflow.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -154,7 +154,7 @@ After versioning, run every gate from the repository root:
 - [ ] Confirm `SKILL.md` exists in every intended package tarball
 - [ ] Execute README installation commands unchanged in a fresh packed consumer
 - [ ] Scan repository release files for secrets and machine-specific paths
-- [ ] Audit production dependencies: `bun audit --production`
+- [ ] Audit published-package production dependencies: `bun run release:audit`
 - [ ] Run whitespace validation last: `git diff --check`
 
 ## Publish

--- a/bun.lock
+++ b/bun.lock
@@ -94,11 +94,11 @@
       "dependencies": {
         "@mdx-js/loader": "3.1.1",
         "@mdx-js/react": "3.1.1",
-        "@next/mdx": "16.2.10",
+        "@next/mdx": "16.2.11",
         "@scribe-sdk/mdx": "workspace:*",
         "@scribe-sdk/react": "workspace:*",
         "@scribe-sdk/styles": "workspace:*",
-        "next": "16.2.10",
+        "next": "16.2.11",
         "react": "19.2.7",
         "react-dom": "19.2.7",
       },
@@ -113,11 +113,11 @@
       "dependencies": {
         "@mdx-js/loader": "3.1.1",
         "@mdx-js/react": "3.1.1",
-        "@next/mdx": "16.2.10",
+        "@next/mdx": "16.2.11",
         "@scribe-sdk/mdx": "workspace:*",
         "@scribe-sdk/react": "workspace:*",
         "@scribe-sdk/styles": "workspace:*",
-        "next": "16.2.10",
+        "next": "16.2.11",
         "react": "19.2.7",
         "react-dom": "19.2.7",
       },
@@ -133,7 +133,7 @@
         "@scribe-sdk/mdx": "workspace:*",
         "@scribe-sdk/react": "workspace:*",
         "@scribe-sdk/styles": "workspace:*",
-        "next": "16.2.10",
+        "next": "16.2.11",
         "next-mdx-remote": "6.0.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -471,25 +471,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
-    "@next/env": ["@next/env@16.2.10", "", {}, "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA=="],
+    "@next/env": ["@next/env@16.2.11", "", {}, "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA=="],
 
-    "@next/mdx": ["@next/mdx@16.2.10", "", { "dependencies": { "source-map": "^0.7.0" }, "peerDependencies": { "@mdx-js/loader": ">=0.15.0", "@mdx-js/react": ">=0.15.0" }, "optionalPeers": ["@mdx-js/loader", "@mdx-js/react"] }, "sha512-r6T32AyQ0xy6p0vKd1lNbz6RUXuVXdGYSAI0dRrpbnqGnTWQXefADZGui4PlwjqROj0XQBMqVwot9ntPWao9PA=="],
+    "@next/mdx": ["@next/mdx@16.2.11", "", { "dependencies": { "source-map": "^0.7.0" }, "peerDependencies": { "@mdx-js/loader": ">=0.15.0", "@mdx-js/react": ">=0.15.0" }, "optionalPeers": ["@mdx-js/loader", "@mdx-js/react"] }, "sha512-9y/dvZAUwANCm9S2I/CaE/XJ7j6eBYQmLohfXlP+LTtjItDAMu+vbg8pxYlT/8EaT4NxyyxOJcHyTUclk86jVg=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.10", "", { "os": "linux", "cpu": "x64" }, "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.11", "", { "os": "linux", "cpu": "x64" }, "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.10", "", { "os": "linux", "cpu": "x64" }, "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.11", "", { "os": "linux", "cpu": "x64" }, "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.10", "", { "os": "win32", "cpu": "x64" }, "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.11", "", { "os": "win32", "cpu": "x64" }, "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -1321,7 +1321,7 @@
 
     "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
-    "next": ["next@16.2.10", "", { "dependencies": { "@next/env": "16.2.10", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.10", "@next/swc-darwin-x64": "16.2.10", "@next/swc-linux-arm64-gnu": "16.2.10", "@next/swc-linux-arm64-musl": "16.2.10", "@next/swc-linux-x64-gnu": "16.2.10", "@next/swc-linux-x64-musl": "16.2.10", "@next/swc-win32-arm64-msvc": "16.2.10", "@next/swc-win32-x64-msvc": "16.2.10", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA=="],
+    "next": ["next@16.2.11", "", { "dependencies": { "@next/env": "16.2.11", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.11", "@next/swc-darwin-x64": "16.2.11", "@next/swc-linux-arm64-gnu": "16.2.11", "@next/swc-linux-arm64-musl": "16.2.11", "@next/swc-linux-x64-gnu": "16.2.11", "@next/swc-linux-x64-musl": "16.2.11", "@next/swc-win32-arm64-msvc": "16.2.11", "@next/swc-win32-x64-msvc": "16.2.11", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ=="],
 
     "next-mdx-remote": ["next-mdx-remote@6.0.0", "", { "dependencies": { "@babel/code-frame": "^7.23.5", "@mdx-js/mdx": "^3.0.1", "@mdx-js/react": "^3.0.1", "unist-util-remove": "^4.0.0", "unist-util-visit": "^5.1.0", "vfile": "^6.0.1", "vfile-matter": "^5.0.0" }, "peerDependencies": { "react": ">=16" } }, "sha512-cJEpEZlgD6xGjB4jL8BnI8FaYdN9BzZM4NwadPe1YQr7pqoWjg9EBCMv3nXBkuHqMRfv2y33SzUsuyNh9LFAQQ=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "docs:sync": "node scripts/sync-package-docs.mjs",
     "release:inspect": "node scripts/inspect-tarballs.mjs .scribe-release",
     "release:bundle-scan": "node scripts/scan-browser-bundles.mjs",
+    "release:audit": "node scripts/audit-public-packages.mjs",
     "release:check": "node scripts/check-release-alignment.mjs",
     "release:consumers": "node scripts/test-packed-consumers.mjs",
     "release:pack": "node scripts/pack-packages.mjs",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,7 +6,7 @@ Scribe is an open-source publishing SDK that turns ordinary Markdown, MDX, seman
 
 Scribe is for developers who already own a React website built with Next.js or Vite and want publication-grade typography, code, tables, banners, callouts, figures, responsive behavior, and accessibility without assembling a publishing design system themselves. It transforms semantic article content at build time and renders it through a small React component map plus scoped CSS.
 
-Scribe is not a hosted blogging platform, CMS, website builder, rich-text editor, proprietary content format, collaboration service, or replacement for React, Next.js, MDX, routing, deployment, analytics, or content storage. The public alpha is tested against React 19.2.7, Next.js 16.2.10, Vite 8.1.3, and MDX 3.1.1. Broader compatibility will be validated through real integrations.
+Scribe is not a hosted blogging platform, CMS, website builder, rich-text editor, proprietary content format, collaboration service, or replacement for React, Next.js, MDX, routing, deployment, analytics, or content storage. The public alpha is tested against React 19.2.7, Next.js 16.2.11, Vite 8.1.3, and MDX 3.1.1. Broader compatibility will be validated through real integrations.
 
 ## Packages
 
@@ -117,10 +117,10 @@ Initialization is minimal and idempotent. It does not replace existing remark/re
 
 ## Next.js MDX integration
 
-The tested Next.js path uses Next 16.2.10 and React 19.2.7. Install Next’s MDX integration if the host does not already have it:
+The tested Next.js path uses Next 16.2.11 and React 19.2.7. Install Next’s MDX integration if the host does not already have it:
 
 ```bash
-bun add @next/mdx@16.2.10 @mdx-js/loader@3.1.1 @mdx-js/react@3.1.1
+bun add @next/mdx@16.2.11 @mdx-js/loader@3.1.1 @mdx-js/react@3.1.1
 ```
 
 Configure the shared Scribe compiler in `next.config.mjs`:
@@ -460,7 +460,7 @@ Scribe owns publication structure, semantic component mappings, responsive artic
 
 The current public-alpha matrix uses fresh packed tarballs for installation, strict typechecking, and production-build claims:
 
-- Framework integrations: React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.10, `@next/mdx` 16.2.10, and `next-mdx-remote` 6.0.0.
+- Framework integrations: React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.11, `@next/mdx` 16.2.11, and `next-mdx-remote` 6.0.0.
 - Declarations: TypeScript 7.0.2 and 6.0.2 with `skipLibCheck: false`.
 - Package and CLI portability: Linux, Windows, and macOS using Bun 1.3.13 and an npm-compatible install flow.
 - Browser behavior: current Playwright-managed Chromium and Firefox, including console errors, uncaught page errors, host isolation, and narrow-viewport overflow.

--- a/packages/cli/src/init.test.ts
+++ b/packages/cli/src/init.test.ts
@@ -141,7 +141,7 @@ it("keeps the Scribe Tailwind layer after Tailwind v4's required import", async 
 
 it("creates but never duplicates an unambiguous Next component map", async () => {
   const cwd = await project({
-    "package.json": JSON.stringify({ ...packages, dependencies: { ...packages.dependencies, next: "16.2.10", "@next/mdx": "16.2.10" } }),
+    "package.json": JSON.stringify({ ...packages, dependencies: { ...packages.dependencies, next: "16.2.11", "@next/mdx": "16.2.11" } }),
     "app/globals.css": "body { margin: 0; }\n",
     "next.config.mjs": "import createMDX from '@next/mdx';\nexport default createMDX({})({});\n"
   });
@@ -155,7 +155,7 @@ it("creates but never duplicates an unambiguous Next component map", async () =>
 
 it("names the next-mdx-remote/rsc options prop precisely", async () => {
   const cwd = await project({
-    "package.json": JSON.stringify({ ...packages, dependencies: { ...packages.dependencies, next: "16.2.10", "next-mdx-remote": "6.0.0" } }),
+    "package.json": JSON.stringify({ ...packages, dependencies: { ...packages.dependencies, next: "16.2.11", "next-mdx-remote": "6.0.0" } }),
     "app/globals.css": "body { margin: 0; }\n",
     "app/page.tsx": 'import { MDXRemote } from "next-mdx-remote/rsc"; export default () => <MDXRemote source="# Article" />;'
   });

--- a/packages/cli/src/rich-preservation.ts
+++ b/packages/cli/src/rich-preservation.ts
@@ -26,6 +26,8 @@ export type RichCandidateResult =
       readonly islandId?: string;
     };
 
+type RichCandidateCompiler = (input: { readonly path: string; readonly value: string }) => Promise<unknown>;
+
 type ProtectedIslandKind =
   | "frontmatter"
   | "mdxjsEsm"
@@ -112,7 +114,7 @@ export async function acceptRichCandidate(
   projection: RichProjection,
   candidate: string,
   path = "scribe-rich-candidate.mdx",
-  compileCandidate: typeof compileScribeMdx = compileScribeMdx
+  compileCandidate: RichCandidateCompiler = compileScribeMdx
 ): Promise<RichCandidateResult> {
   let placeholders: readonly CandidatePlaceholder[];
   try {

--- a/packages/cli/src/studio-compiler.test.ts
+++ b/packages/cli/src/studio-compiler.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, expect, it } from "vitest";
+
+import { StudioCompiler } from "./studio-compiler.js";
+
+const compilers: StudioCompiler[] = [];
+afterEach(async () => Promise.all(compilers.splice(0).map((compiler) => compiler.close())));
+
+it("validates MDX in an isolated reusable worker", async () => {
+  const compiler = new StudioCompiler();
+  compilers.push(compiler);
+
+  await expect(compiler.compile("/tmp/article.mdx", "# Valid\n")).resolves.toEqual([]);
+  await expect(compiler.compile("/tmp/article.mdx", "<Callout>unfinished")).resolves.toEqual([
+    expect.objectContaining({ severity: "error", line: 1 })
+  ]);
+});
+
+it("keeps the caller event loop responsive while compilation runs", async () => {
+  const compiler = new StudioCompiler();
+  compilers.push(compiler);
+  const compilation = compiler.compile("/tmp/long.mdx", `${"# Heading\n\nParagraph.\n\n".repeat(2_000)}`);
+  let timerRan = false;
+  await new Promise<void>((resolve) => setTimeout(() => {
+    timerRan = true;
+    resolve();
+  }, 0));
+
+  expect(timerRan).toBe(true);
+  await expect(compilation).resolves.toEqual([]);
+});
+
+it("restarts after a worker failure without leaving requests pending", async () => {
+  const compiler = new StudioCompiler("file:///definitely-missing-scribe-mdx.mjs");
+  compilers.push(compiler);
+
+  await expect(compiler.compile("/tmp/article.mdx", "# First\n")).rejects.toThrow();
+  await expect(compiler.compile("/tmp/article.mdx", "# Second\n")).rejects.toThrow();
+});
+
+it("times out a stuck compiler worker instead of hanging the Studio transaction queue", async () => {
+  const hangingModule = `data:text/javascript,${encodeURIComponent("export async function compileScribeMdx(){return new Promise(()=>{})}")}`;
+  const compiler = new StudioCompiler(hangingModule, 25);
+  compilers.push(compiler);
+
+  await expect(compiler.compile("/tmp/article.mdx", "# Never returns\n")).rejects.toThrow("exceeded 25ms");
+});

--- a/packages/cli/src/studio-compiler.test.ts
+++ b/packages/cli/src/studio-compiler.test.ts
@@ -1,6 +1,12 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { afterEach, expect, it } from "vitest";
 
 import { StudioCompiler } from "./studio-compiler.js";
+
+const articlePath = join(tmpdir(), "article.mdx");
+const longArticlePath = join(tmpdir(), "long.mdx");
 
 const compilers: StudioCompiler[] = [];
 afterEach(async () => Promise.all(compilers.splice(0).map((compiler) => compiler.close())));
@@ -9,8 +15,8 @@ it("validates MDX in an isolated reusable worker", async () => {
   const compiler = new StudioCompiler();
   compilers.push(compiler);
 
-  await expect(compiler.compile("/tmp/article.mdx", "# Valid\n")).resolves.toEqual([]);
-  await expect(compiler.compile("/tmp/article.mdx", "<Callout>unfinished")).resolves.toEqual([
+  await expect(compiler.compile(articlePath, "# Valid\n")).resolves.toEqual([]);
+  await expect(compiler.compile(articlePath, "<Callout>unfinished")).resolves.toEqual([
     expect.objectContaining({ severity: "error", line: 1 })
   ]);
 });
@@ -18,7 +24,7 @@ it("validates MDX in an isolated reusable worker", async () => {
 it("keeps the caller event loop responsive while compilation runs", async () => {
   const compiler = new StudioCompiler();
   compilers.push(compiler);
-  const compilation = compiler.compile("/tmp/long.mdx", `${"# Heading\n\nParagraph.\n\n".repeat(2_000)}`);
+  const compilation = compiler.compile(longArticlePath, `${"# Heading\n\nParagraph.\n\n".repeat(2_000)}`);
   let timerRan = false;
   await new Promise<void>((resolve) => setTimeout(() => {
     timerRan = true;
@@ -33,8 +39,8 @@ it("restarts after a worker failure without leaving requests pending", async () 
   const compiler = new StudioCompiler("file:///definitely-missing-scribe-mdx.mjs");
   compilers.push(compiler);
 
-  await expect(compiler.compile("/tmp/article.mdx", "# First\n")).rejects.toThrow();
-  await expect(compiler.compile("/tmp/article.mdx", "# Second\n")).rejects.toThrow();
+  await expect(compiler.compile(articlePath, "# First\n")).rejects.toThrow();
+  await expect(compiler.compile(articlePath, "# Second\n")).rejects.toThrow();
 });
 
 it("times out a stuck compiler worker instead of hanging the Studio transaction queue", async () => {
@@ -42,5 +48,5 @@ it("times out a stuck compiler worker instead of hanging the Studio transaction 
   const compiler = new StudioCompiler(hangingModule, 25);
   compilers.push(compiler);
 
-  await expect(compiler.compile("/tmp/article.mdx", "# Never returns\n")).rejects.toThrow("exceeded 25ms");
+  await expect(compiler.compile(articlePath, "# Never returns\n")).rejects.toThrow("exceeded 25ms");
 });

--- a/packages/cli/src/studio-compiler.ts
+++ b/packages/cli/src/studio-compiler.ts
@@ -1,0 +1,142 @@
+import { Worker } from "node:worker_threads";
+
+export interface StudioCompilerDiagnostic {
+  readonly severity: "error" | "warning";
+  readonly code: string;
+  readonly message: string;
+  readonly line?: number;
+  readonly column?: number;
+}
+
+interface PendingCompilation {
+  readonly resolve: (diagnostics: StudioCompilerDiagnostic[]) => void;
+  readonly reject: (error: Error) => void;
+  readonly timer: ReturnType<typeof setTimeout>;
+}
+
+interface WorkerResult {
+  readonly id: number;
+  readonly diagnostics?: StudioCompilerDiagnostic[];
+  readonly error?: string;
+}
+
+export class StudioCompiler {
+  #worker: Worker;
+  readonly #pending = new Map<number, PendingCompilation>();
+  readonly #mdxModuleUrl: string;
+  readonly #timeoutMilliseconds: number;
+  #nextId = 0;
+  #closed = false;
+
+  constructor(
+    mdxModuleUrl = import.meta.resolve("@scribe-sdk/mdx"),
+    timeoutMilliseconds = 30_000
+  ) {
+    this.#mdxModuleUrl = mdxModuleUrl;
+    this.#timeoutMilliseconds = timeoutMilliseconds;
+    this.#worker = this.#createWorker();
+  }
+
+  #createWorker(): Worker {
+    const source = workerSource(this.#mdxModuleUrl);
+    const worker = new Worker(new URL(`data:text/javascript,${encodeURIComponent(source)}`), {
+      name: "scribe-studio-compiler"
+    });
+    worker.on("message", (message: WorkerResult) => {
+      if (this.#worker !== worker) return;
+      const pending = this.#pending.get(message.id);
+      if (pending === undefined) return;
+      clearTimeout(pending.timer);
+      this.#pending.delete(message.id);
+      if (message.error !== undefined) pending.reject(new Error(message.error));
+      else pending.resolve(message.diagnostics ?? []);
+    });
+    worker.on("error", (error) => this.#restartWorker(worker, error));
+    worker.on("exit", (code) => {
+      if (!this.#closed && this.#worker === worker) {
+        this.#restartWorker(worker, new Error(`Studio compiler worker exited unexpectedly with code ${code}.`));
+      }
+    });
+    return worker;
+  }
+
+  compile(path: string, source: string): Promise<StudioCompilerDiagnostic[]> {
+    if (this.#closed) return Promise.reject(new Error("Studio compiler is closed."));
+    const id = ++this.#nextId;
+    return new Promise((resolve, reject) => {
+      const worker = this.#worker;
+      const timer = setTimeout(() => {
+        if (!this.#pending.has(id)) return;
+        this.#restartWorker(
+          worker,
+          new Error(`Studio compilation exceeded ${this.#timeoutMilliseconds}ms and the compiler worker was restarted.`)
+        );
+      }, this.#timeoutMilliseconds);
+      this.#pending.set(id, { resolve, reject, timer });
+      try {
+        worker.postMessage({ id, path, source });
+      } catch (error) {
+        clearTimeout(timer);
+        this.#pending.delete(id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#rejectPending(new Error("Studio compiler closed before validation completed."));
+    await this.#worker.terminate();
+  }
+
+  #restartWorker(worker: Worker, error: Error): void {
+    if (this.#closed || this.#worker !== worker) return;
+    this.#rejectPending(error);
+    this.#worker = this.#createWorker();
+    void worker.terminate();
+  }
+
+  #rejectPending(error: Error): void {
+    for (const pending of this.#pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.#pending.clear();
+  }
+}
+
+function workerSource(mdxModuleUrl: string): string {
+  return `
+import { parentPort } from "node:worker_threads";
+import { compileScribeMdx } from ${JSON.stringify(mdxModuleUrl)};
+
+parentPort.on("message", async ({ id, path, source }) => {
+  try {
+    const file = await compileScribeMdx({ path, value: source });
+    parentPort.postMessage({
+      id,
+      diagnostics: file.messages.map((message) => ({
+        severity: "warning",
+        code: message.ruleId ?? "SCB0001",
+        message: message.reason,
+        ...(message.line === undefined ? {} : { line: message.line }),
+        ...(message.column === undefined ? {} : { column: message.column })
+      }))
+    });
+  } catch (error) {
+    const diagnostic = error;
+    parentPort.postMessage({
+      id,
+      diagnostics: [{
+        severity: "error",
+        code: diagnostic.ruleId ?? "SCB0001",
+        message: diagnostic.reason ?? diagnostic.message ?? String(error),
+        ...(diagnostic.line === undefined ? {} : { line: diagnostic.line }),
+        ...(diagnostic.column === undefined ? {} : { column: diagnostic.column })
+      }]
+    });
+  }
+});
+`;
+}

--- a/packages/cli/src/studio-events.test.ts
+++ b/packages/cli/src/studio-events.test.ts
@@ -1,0 +1,42 @@
+import { expect, it, vi } from "vitest";
+
+import { StudioEventHub } from "./studio-events.js";
+
+it("broadcasts revisions and detaches closed Studio clients", () => {
+  const hub = new StudioEventHub();
+  const first = vi.fn();
+  const second = vi.fn();
+  const unsubscribe = hub.subscribe(first);
+  hub.subscribe(second);
+
+  hub.publish(2);
+  unsubscribe();
+  hub.publish(3);
+
+  expect(first.mock.calls).toEqual([[2]]);
+  expect(second.mock.calls).toEqual([[2], [3]]);
+});
+
+it("notifies transports when Studio shuts down", () => {
+  const hub = new StudioEventHub();
+  const close = vi.fn();
+  hub.onClose(close);
+  hub.close();
+  expect(close).toHaveBeenCalledOnce();
+});
+
+it("isolates a broken transport from the remaining Studio clients", () => {
+  const hub = new StudioEventHub();
+  const healthy = vi.fn();
+  const broken = vi.fn(() => {
+    throw new Error("socket closed");
+  });
+  hub.subscribe(broken);
+  hub.subscribe(healthy);
+
+  expect(() => hub.publish(4)).not.toThrow();
+  hub.publish(5);
+
+  expect(broken).toHaveBeenCalledOnce();
+  expect(healthy.mock.calls).toEqual([[4], [5]]);
+});

--- a/packages/cli/src/studio-events.ts
+++ b/packages/cli/src/studio-events.ts
@@ -1,0 +1,36 @@
+export class StudioEventHub {
+  readonly #listeners = new Set<(revision: number) => void>();
+  readonly #closeListeners = new Set<() => void>();
+
+  publish(revision: number): void {
+    for (const listener of this.#listeners) {
+      try {
+        listener(revision);
+      } catch {
+        this.#listeners.delete(listener);
+      }
+    }
+  }
+
+  subscribe(listener: (revision: number) => void): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  onClose(listener: () => void): () => void {
+    this.#closeListeners.add(listener);
+    return () => this.#closeListeners.delete(listener);
+  }
+
+  close(): void {
+    for (const listener of this.#closeListeners) {
+      try {
+        listener();
+      } catch {
+        // One failed transport must not prevent the remaining clients from closing.
+      }
+    }
+    this.#listeners.clear();
+    this.#closeListeners.clear();
+  }
+}

--- a/packages/cli/src/studio-files.test.ts
+++ b/packages/cli/src/studio-files.test.ts
@@ -1,0 +1,85 @@
+import { chmod, lstat, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { expect, it } from "vitest";
+
+import { durableWriteStudioFile, readStudioFile, StudioFileConflictError } from "./studio-files.js";
+
+async function sourceFile(source = "# Original\n"): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "scribe durable "));
+  const path = join(root, "article.mdx");
+  await writeFile(path, source);
+  return path;
+}
+
+it("durably replaces the resolved target without replacing a source symlink", async () => {
+  const target = await sourceFile();
+  await chmod(target, 0o640);
+  const link = join(target, "..", "linked.mdx");
+  await symlink(target, link);
+  const snapshot = await readStudioFile(link);
+
+  const committed = await durableWriteStudioFile({
+    requestedPath: snapshot.requestedPath,
+    resolvedPath: snapshot.resolvedPath,
+    expectedVersion: snapshot.version,
+    expectedDevice: snapshot.device,
+    expectedInode: snapshot.inode,
+    lineEnding: snapshot.lineEnding,
+    bom: snapshot.bom,
+    mode: snapshot.mode,
+    source: "# Saved\n"
+  });
+
+  expect((await lstat(link)).isSymbolicLink()).toBe(true);
+  expect(await readFile(target, "utf8")).toBe("# Saved\n");
+  expect(committed.source).toBe("# Saved\n");
+  expect((await lstat(target)).mode & 0o777).toBe(0o640);
+});
+
+it("detects an edit in the final commit window and removes its temporary file", async () => {
+  const path = await sourceFile();
+  const snapshot = await readStudioFile(path);
+
+  await expect(durableWriteStudioFile({
+    requestedPath: snapshot.requestedPath,
+    resolvedPath: snapshot.resolvedPath,
+    expectedVersion: snapshot.version,
+    expectedDevice: snapshot.device,
+    expectedInode: snapshot.inode,
+    lineEnding: snapshot.lineEnding,
+    bom: snapshot.bom,
+    mode: snapshot.mode,
+    source: "# Studio\n",
+    beforeCommit: async () => writeFile(path, "# External\n")
+  })).rejects.toBeInstanceOf(StudioFileConflictError);
+
+  expect(await readFile(path, "utf8")).toBe("# External\n");
+  const directory = await import("node:fs/promises").then(({ readdir }) => readdir(join(path, "..")));
+  expect(directory.some((name) => name.includes(".scribe-") && name.endsWith(".tmp"))).toBe(false);
+});
+
+it("preserves a UTF-8 BOM and CRLF line endings", async () => {
+  const path = await sourceFile("\uFEFF# Original\r\n\r\nBody.\r\n");
+  const snapshot = await readStudioFile(path);
+  expect(snapshot).toMatchObject({ bom: true, lineEnding: "\r\n", source: "# Original\r\n\r\nBody.\r\n" });
+
+  await durableWriteStudioFile({
+    requestedPath: snapshot.requestedPath,
+    resolvedPath: snapshot.resolvedPath,
+    expectedVersion: snapshot.version,
+    expectedDevice: snapshot.device,
+    expectedInode: snapshot.inode,
+    lineEnding: snapshot.lineEnding,
+    bom: snapshot.bom,
+    mode: snapshot.mode,
+    source: "# Saved\n\nBody.\n"
+  });
+  expect(await readFile(path, "utf8")).toBe("\uFEFF# Saved\r\n\r\nBody.\r\n");
+});
+
+it("refuses mixed line endings instead of silently normalizing them", async () => {
+  const path = await sourceFile("# Mixed\r\n\nBody\r\n");
+  await expect(readStudioFile(path)).rejects.toThrow("mixed LF and CRLF");
+});

--- a/packages/cli/src/studio-files.ts
+++ b/packages/cli/src/studio-files.ts
@@ -1,0 +1,139 @@
+import { createHash, randomBytes } from "node:crypto";
+import { open, readFile, realpath, rename, stat, unlink } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export interface StudioFileSnapshot {
+  readonly requestedPath: string;
+  readonly resolvedPath: string;
+  readonly source: string;
+  readonly version: string;
+  readonly lineEnding: "\n" | "\r\n";
+  readonly bom: boolean;
+  readonly mode: number;
+  readonly device: number;
+  readonly inode: number;
+}
+
+export interface DurableStudioWrite {
+  readonly requestedPath: string;
+  readonly resolvedPath: string;
+  readonly expectedVersion: string;
+  readonly expectedDevice: number;
+  readonly expectedInode: number;
+  readonly source: string;
+  readonly lineEnding: "\n" | "\r\n";
+  readonly bom: boolean;
+  readonly mode: number;
+  readonly beforeCommit?: () => Promise<void>;
+}
+
+export class StudioFileConflictError extends Error {
+  constructor(message = "The source changed outside Studio before the save could commit.") {
+    super(message);
+    this.name = "StudioFileConflictError";
+  }
+}
+
+export async function readStudioFile(requestedPath: string): Promise<StudioFileSnapshot> {
+  const resolvedPath = await realpath(requestedPath);
+  const [bytes, info] = await Promise.all([readFile(resolvedPath), stat(resolvedPath)]);
+  if (!info.isFile()) throw new Error(`Studio source is not a regular file: ${requestedPath}`);
+  const bom = bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf;
+  const content = bom ? bytes.subarray(3) : bytes;
+  let source: string;
+  try {
+    source = new TextDecoder("utf-8", { fatal: true }).decode(content);
+  } catch {
+    throw new Error(`Studio could not decode ${requestedPath} as UTF-8.`);
+  }
+  return {
+    requestedPath,
+    resolvedPath,
+    source,
+    version: fingerprintBytes(bytes),
+    lineEnding: detectLineEnding(source),
+    bom,
+    mode: info.mode,
+    device: info.dev,
+    inode: info.ino
+  };
+}
+
+export async function durableWriteStudioFile(options: DurableStudioWrite): Promise<StudioFileSnapshot> {
+  const currentResolved = await realpath(options.requestedPath);
+  if (currentResolved !== options.resolvedPath) {
+    throw new StudioFileConflictError("The source symlink or file target changed outside Studio.");
+  }
+
+  const bytes = encodeStudioSource(options.source, options.lineEnding, options.bom);
+  const temporaryPath = `${options.resolvedPath}.scribe-${process.pid}-${randomBytes(8).toString("hex")}.tmp`;
+  let temporaryExists = false;
+  try {
+    const temporary = await open(temporaryPath, "wx", options.mode & 0o777);
+    temporaryExists = true;
+    try {
+      await temporary.writeFile(bytes);
+      await temporary.sync();
+    } finally {
+      await temporary.close();
+    }
+
+    if (options.beforeCommit !== undefined) await options.beforeCommit();
+
+    const [currentBytes, currentInfo, resolvedAgain] = await Promise.all([
+      readFile(options.resolvedPath),
+      stat(options.resolvedPath),
+      realpath(options.requestedPath)
+    ]);
+    if (
+      resolvedAgain !== options.resolvedPath
+      || fingerprintBytes(currentBytes) !== options.expectedVersion
+      || currentInfo.dev !== options.expectedDevice
+      || currentInfo.ino !== options.expectedInode
+    ) {
+      throw new StudioFileConflictError();
+    }
+
+    await rename(temporaryPath, options.resolvedPath);
+    temporaryExists = false;
+    await syncDirectory(dirname(options.resolvedPath));
+
+    const committed = await readFile(options.resolvedPath);
+    if (!committed.equals(bytes)) {
+      throw new Error("Studio could not verify the bytes written to the source file.");
+    }
+    return readStudioFile(options.requestedPath);
+  } finally {
+    if (temporaryExists) await unlink(temporaryPath).catch(() => undefined);
+  }
+}
+
+export function encodeStudioSource(source: string, lineEnding: "\n" | "\r\n", bom: boolean): Buffer {
+  const normalized = source.replace(/\r\n?|\n/gu, "\n").replaceAll("\n", lineEnding);
+  return Buffer.from(`${bom ? "\uFEFF" : ""}${normalized}`, "utf8");
+}
+
+function detectLineEnding(source: string): "\n" | "\r\n" {
+  const crlf = source.match(/\r\n/gu)?.length ?? 0;
+  const lf = source.match(/(?<!\r)\n/gu)?.length ?? 0;
+  if (crlf > 0 && lf > 0) {
+    throw new Error("Studio does not edit files with mixed LF and CRLF line endings. Normalize the file first to avoid silent rewriting.");
+  }
+  return crlf > 0 ? "\r\n" : "\n";
+}
+
+function fingerprintBytes(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  const directory = await open(path, "r");
+  try {
+    await directory.sync();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (process.platform !== "win32" || (code !== "EINVAL" && code !== "ENOTSUP" && code !== "EPERM")) throw error;
+  } finally {
+    await directory.close();
+  }
+}

--- a/packages/cli/src/studio-files.ts
+++ b/packages/cli/src/studio-files.ts
@@ -2,6 +2,8 @@ import { createHash, randomBytes } from "node:crypto";
 import { open, readFile, realpath, rename, stat, unlink } from "node:fs/promises";
 import { dirname } from "node:path";
 
+import { syncDirectory } from "./studio-fs.js";
+
 export interface StudioFileSnapshot {
   readonly requestedPath: string;
   readonly resolvedPath: string;
@@ -124,16 +126,4 @@ function detectLineEnding(source: string): "\n" | "\r\n" {
 
 function fingerprintBytes(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
-}
-
-async function syncDirectory(path: string): Promise<void> {
-  const directory = await open(path, "r");
-  try {
-    await directory.sync();
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (process.platform !== "win32" || (code !== "EINVAL" && code !== "ENOTSUP" && code !== "EPERM")) throw error;
-  } finally {
-    await directory.close();
-  }
 }

--- a/packages/cli/src/studio-fs.ts
+++ b/packages/cli/src/studio-fs.ts
@@ -1,0 +1,19 @@
+import { open } from "node:fs/promises";
+
+export async function syncDirectory(path: string): Promise<void> {
+  let directory: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    directory = await open(path, "r");
+    await directory.sync();
+  } catch (error) {
+    if (!isUnsupportedWindowsDirectorySync(error)) throw error;
+  } finally {
+    await directory?.close();
+  }
+}
+
+function isUnsupportedWindowsDirectorySync(error: unknown): boolean {
+  if (process.platform !== "win32") return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "EINVAL" || code === "ENOTSUP" || code === "EPERM";
+}

--- a/packages/cli/src/studio-lease.test.ts
+++ b/packages/cli/src/studio-lease.test.ts
@@ -1,0 +1,25 @@
+import { expect, it } from "vitest";
+
+import { StudioWriterLease } from "./studio-lease.js";
+
+it("grants one writer, renews it, and refuses a competing tab", () => {
+  let now = 1_000;
+  const lease = new StudioWriterLease(8_000, () => now);
+
+  expect(lease.acquire("tab-a")).toEqual({ granted: true, expiresAt: 9_000 });
+  now = 2_000;
+  expect(lease.acquire("tab-a")).toEqual({ granted: true, expiresAt: 10_000 });
+  expect(lease.acquire("tab-b")).toEqual({ granted: false, expiresAt: 10_000 });
+  expect(lease.holds("tab-a")).toBe(true);
+  expect(lease.holds("tab-b")).toBe(false);
+});
+
+it("allows another tab after expiry or an explicit release", () => {
+  let now = 100;
+  const lease = new StudioWriterLease(50, () => now);
+  lease.acquire("tab-a");
+  now = 151;
+  expect(lease.acquire("tab-b").granted).toBe(true);
+  lease.release("tab-b");
+  expect(lease.acquire("tab-c").granted).toBe(true);
+});

--- a/packages/cli/src/studio-lease.ts
+++ b/packages/cli/src/studio-lease.ts
@@ -1,0 +1,36 @@
+export interface StudioLeaseState {
+  readonly clientId: string;
+  readonly expiresAt: number;
+}
+
+export class StudioWriterLease {
+  #current: StudioLeaseState | undefined;
+
+  constructor(
+    private readonly durationMilliseconds = 8_000,
+    private readonly now: () => number = Date.now
+  ) {}
+
+  acquire(clientId: string): { readonly granted: boolean; readonly expiresAt: number } {
+    const time = this.now();
+    if (this.#current !== undefined && this.#current.expiresAt > time && this.#current.clientId !== clientId) {
+      return { granted: false, expiresAt: this.#current.expiresAt };
+    }
+    const expiresAt = time + this.durationMilliseconds;
+    this.#current = { clientId, expiresAt };
+    return { granted: true, expiresAt };
+  }
+
+  holds(clientId: string): boolean {
+    const time = this.now();
+    if (this.#current === undefined || this.#current.expiresAt <= time) {
+      this.#current = undefined;
+      return false;
+    }
+    return this.#current.clientId === clientId;
+  }
+
+  release(clientId: string): void {
+    if (this.#current?.clientId === clientId) this.#current = undefined;
+  }
+}

--- a/packages/cli/src/studio-recovery.test.ts
+++ b/packages/cli/src/studio-recovery.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { expect, it } from "vitest";
+
+import { StudioRecoveryStore } from "./studio-recovery.js";
+
+it("durably restores the latest accepted unsaved draft", async () => {
+  const root = await mkdtemp(join(tmpdir(), "scribe recovery "));
+  const store = new StudioRecoveryStore("/project/content/article.mdx", root);
+  await store.writeDraft({
+    sourcePath: "/project/content/article.mdx",
+    baseDiskVersion: "disk-a",
+    draftSource: "# Unsaved\n",
+    revision: 7
+  });
+
+  await expect(new StudioRecoveryStore("/project/content/article.mdx", root).loadDraft()).resolves.toMatchObject({
+    baseDiskVersion: "disk-a",
+    draftSource: "# Unsaved\n",
+    revision: 7
+  });
+  expect((await readdir(join(root, "recovery"))).every((name) => !name.includes("article.mdx"))).toBe(true);
+});
+
+it("archives discarded drafts so they remain recoverable", async () => {
+  const root = await mkdtemp(join(tmpdir(), "scribe recovery "));
+  const store = new StudioRecoveryStore("/project/article.mdx", root);
+  await store.writeDraft({
+    sourcePath: "/project/article.mdx",
+    baseDiskVersion: "disk-a",
+    draftSource: "# Discard me\n",
+    revision: 3
+  });
+
+  await store.archiveDraft("discarded");
+  await expect(store.loadDraft()).resolves.toBeUndefined();
+  await expect(store.loadLatestArchive("discarded")).resolves.toMatchObject({ draftSource: "# Discard me\n" });
+});
+
+it("quarantines a corrupted active record instead of trusting it", async () => {
+  const root = await mkdtemp(join(tmpdir(), "scribe recovery "));
+  const store = new StudioRecoveryStore("/project/article.mdx", root);
+  await store.writeDraft({
+    sourcePath: "/project/article.mdx",
+    baseDiskVersion: "disk-a",
+    draftSource: "# Safe\n",
+    revision: 1
+  });
+  const directory = join(root, "recovery");
+  const active = (await readdir(directory)).find((name) => name.endsWith(".json"));
+  if (active === undefined) throw new Error("Recovery fixture was not written.");
+  const value = JSON.parse(await readFile(join(directory, active), "utf8")) as { draftSource: string };
+  value.draftSource = "# Tampered\n";
+  await writeFile(join(directory, active), JSON.stringify(value));
+
+  await expect(store.loadDraft()).resolves.toBeUndefined();
+  expect((await readdir(directory)).some((name) => name.endsWith(".corrupt"))).toBe(true);
+});

--- a/packages/cli/src/studio-recovery.test.ts
+++ b/packages/cli/src/studio-recovery.test.ts
@@ -1,10 +1,10 @@
-import { mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { expect, it } from "vitest";
 
-import { StudioRecoveryStore } from "./studio-recovery.js";
+import { StudioRecoveryStore, studioRecoveryKey } from "./studio-recovery.js";
 
 it("durably restores the latest accepted unsaved draft", async () => {
   const root = await mkdtemp(join(tmpdir(), "scribe recovery "));
@@ -57,4 +57,42 @@ it("quarantines a corrupted active record instead of trusting it", async () => {
 
   await expect(store.loadDraft()).resolves.toBeUndefined();
   expect((await readdir(directory)).some((name) => name.endsWith(".corrupt"))).toBe(true);
+});
+
+it("propagates recovery read failures instead of quarantining inaccessible records", async () => {
+  const root = await mkdtemp(join(tmpdir(), "scribe recovery "));
+  const sourcePath = "/project/article.mdx";
+  const activePath = join(root, "recovery", `${studioRecoveryKey(sourcePath)}.json`);
+  await mkdir(activePath, { recursive: true });
+
+  await expect(new StudioRecoveryStore(sourcePath, root).loadDraft()).rejects.toBeDefined();
+  expect((await readdir(join(root, "recovery")))).toContain(`${studioRecoveryKey(sourcePath)}.json`);
+});
+
+it("trims only recognized completed archives and preserves in-flight temporary files", async () => {
+  const root = await mkdtemp(join(tmpdir(), "scribe recovery "));
+  const sourcePath = "/project/article.mdx";
+  const key = studioRecoveryKey(sourcePath);
+  const directory = join(root, "recovery");
+  await mkdir(directory, { recursive: true });
+  for (let index = 0; index < 22; index += 1) {
+    await writeFile(join(directory, `${key}.${String(1_000 + index)}.deadbeef.checkpoint.json`), "{}");
+  }
+  const temporary = `${key}.0000.deadbeef.checkpoint.json.writer.tmp`;
+  const unrelated = `${key}.0000.unrelated.json`;
+  await writeFile(join(directory, temporary), "in flight");
+  await writeFile(join(directory, unrelated), "unrelated");
+
+  const store = new StudioRecoveryStore(sourcePath, root);
+  await store.writeHistory({
+    sourcePath,
+    baseDiskVersion: "disk-a",
+    draftSource: "# History\n",
+    revision: 4
+  }, "checkpoint");
+
+  const entries = await readdir(directory);
+  expect(entries).toContain(temporary);
+  expect(entries).toContain(unrelated);
+  expect(entries.filter((entry) => /\.(?:discarded|saved|reverted|checkpoint)\.json$/u.test(entry))).toHaveLength(20);
 });

--- a/packages/cli/src/studio-recovery.ts
+++ b/packages/cli/src/studio-recovery.ts
@@ -4,6 +4,8 @@ import { homedir, platform } from "node:os";
 import { dirname, join } from "node:path";
 import { mkdir } from "node:fs/promises";
 
+import { syncDirectory } from "./studio-fs.js";
+
 export interface StudioRecoveryRecord {
   readonly schema: 1;
   readonly sourcePath: string;
@@ -33,10 +35,16 @@ export class StudioRecoveryStore {
   }
 
   async loadDraft(): Promise<StudioRecoveryRecord | undefined> {
+    let source: string;
     try {
-      return validateRecord(JSON.parse(await readFile(this.#activePath, "utf8")));
+      source = await readFile(this.#activePath, "utf8");
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      throw error;
+    }
+    try {
+      return validateRecord(JSON.parse(source));
+    } catch {
       await this.#quarantineCorruptRecord();
       return undefined;
     }
@@ -103,8 +111,9 @@ export class StudioRecoveryStore {
   }
 
   async #trimArchives(): Promise<void> {
+    const archiveName = new RegExp(`^${this.#key}\\.\\d+\\.[0-9a-f]+\\.(?:discarded|saved|reverted|checkpoint)\\.json$`, "u");
     const entries = (await readdir(this.#directory))
-      .filter((entry) => entry.startsWith(`${this.#key}.`) && entry !== `${this.#key}.json` && !entry.endsWith(".corrupt"))
+      .filter((entry) => archiveName.test(entry))
       .sort()
       .reverse();
     await Promise.all(entries.slice(20).map((entry) => unlink(join(this.#directory, entry)).catch(() => undefined)));
@@ -182,17 +191,5 @@ async function durableJsonWrite(path: string, value: unknown): Promise<void> {
     await syncDirectory(directory);
   } finally {
     if (exists) await unlink(temporary).catch(() => undefined);
-  }
-}
-
-async function syncDirectory(path: string): Promise<void> {
-  const directory = await open(path, "r");
-  try {
-    await directory.sync();
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (platform() !== "win32" || (code !== "EINVAL" && code !== "ENOTSUP" && code !== "EPERM")) throw error;
-  } finally {
-    await directory.close();
   }
 }

--- a/packages/cli/src/studio-recovery.ts
+++ b/packages/cli/src/studio-recovery.ts
@@ -1,0 +1,198 @@
+import { createHash, randomBytes } from "node:crypto";
+import { open, readdir, readFile, rename, unlink } from "node:fs/promises";
+import { homedir, platform } from "node:os";
+import { dirname, join } from "node:path";
+import { mkdir } from "node:fs/promises";
+
+export interface StudioRecoveryRecord {
+  readonly schema: 1;
+  readonly sourcePath: string;
+  readonly baseDiskVersion: string;
+  readonly draftSource: string;
+  readonly revision: number;
+  readonly writtenAt: string;
+  readonly checksum: string;
+}
+
+interface RecoveryInput {
+  readonly sourcePath: string;
+  readonly baseDiskVersion: string;
+  readonly draftSource: string;
+  readonly revision: number;
+}
+
+export class StudioRecoveryStore {
+  readonly #directory: string;
+  readonly #activePath: string;
+  readonly #key: string;
+
+  constructor(sourcePath: string, root = defaultStudioStateRoot()) {
+    this.#key = studioRecoveryKey(sourcePath);
+    this.#directory = join(root, "recovery");
+    this.#activePath = join(this.#directory, `${this.#key}.json`);
+  }
+
+  async loadDraft(): Promise<StudioRecoveryRecord | undefined> {
+    try {
+      return validateRecord(JSON.parse(await readFile(this.#activePath, "utf8")));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      await this.#quarantineCorruptRecord();
+      return undefined;
+    }
+  }
+
+  async writeDraft(input: RecoveryInput): Promise<StudioRecoveryRecord> {
+    const record = createRecord(input);
+    await durableJsonWrite(this.#activePath, record);
+    return record;
+  }
+
+  async archiveDraft(reason: "discarded" | "saved" | "reverted"): Promise<string | undefined> {
+    await mkdir(this.#directory, { recursive: true, mode: 0o700 });
+    const archived = join(this.#directory, `${this.#key}.${Date.now()}.${randomBytes(4).toString("hex")}.${reason}.json`);
+    try {
+      await rename(this.#activePath, archived);
+      await syncDirectory(this.#directory);
+      await this.#trimArchives();
+      return archived;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      throw error;
+    }
+  }
+
+  async writeHistory(input: RecoveryInput, reason: "checkpoint"): Promise<string> {
+    await mkdir(this.#directory, { recursive: true, mode: 0o700 });
+    const archived = join(this.#directory, `${this.#key}.${Date.now()}.${randomBytes(4).toString("hex")}.${reason}.json`);
+    await durableJsonWrite(archived, createRecord(input));
+    await this.#trimArchives();
+    return archived;
+  }
+
+  async loadLatestArchive(reason: "discarded" | "saved" | "reverted"): Promise<StudioRecoveryRecord | undefined> {
+    try {
+      const suffix = `.${reason}.json`;
+      const entries = (await readdir(this.#directory))
+        .filter((entry) => entry.startsWith(`${this.#key}.`) && entry.endsWith(suffix))
+        .sort()
+        .reverse();
+      for (const entry of entries) {
+        try {
+          return validateRecord(JSON.parse(await readFile(join(this.#directory, entry), "utf8")));
+        } catch {
+          continue;
+        }
+      }
+      return undefined;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      throw error;
+    }
+  }
+
+  async removeActiveDraft(): Promise<void> {
+    await unlink(this.#activePath).catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== "ENOENT") throw error;
+    });
+  }
+
+  async #quarantineCorruptRecord(): Promise<void> {
+    const quarantine = `${this.#activePath}.${Date.now()}.corrupt`;
+    await rename(this.#activePath, quarantine).catch(() => undefined);
+  }
+
+  async #trimArchives(): Promise<void> {
+    const entries = (await readdir(this.#directory))
+      .filter((entry) => entry.startsWith(`${this.#key}.`) && entry !== `${this.#key}.json` && !entry.endsWith(".corrupt"))
+      .sort()
+      .reverse();
+    await Promise.all(entries.slice(20).map((entry) => unlink(join(this.#directory, entry)).catch(() => undefined)));
+  }
+}
+
+export function studioRecoveryKey(sourcePath: string): string {
+  return createHash("sha256").update(sourcePath).digest("hex");
+}
+
+export function defaultStudioStateRoot(): string {
+  if (process.env["SCRIBE_STUDIO_STATE_DIR"]) return process.env["SCRIBE_STUDIO_STATE_DIR"];
+  if (platform() === "win32") return join(process.env["LOCALAPPDATA"] ?? homedir(), "Scribe Studio");
+  if (platform() === "darwin") return join(homedir(), "Library", "Application Support", "Scribe Studio");
+  return join(process.env["XDG_STATE_HOME"] ?? join(homedir(), ".local", "state"), "scribe-studio");
+}
+
+function createRecord(input: RecoveryInput): StudioRecoveryRecord {
+  const writtenAt = new Date().toISOString();
+  return {
+    schema: 1,
+    ...input,
+    writtenAt,
+    checksum: checksum(input)
+  };
+}
+
+function validateRecord(value: unknown): StudioRecoveryRecord {
+  if (
+    typeof value !== "object"
+    || value === null
+    || (value as Partial<StudioRecoveryRecord>).schema !== 1
+    || typeof (value as Partial<StudioRecoveryRecord>).sourcePath !== "string"
+    || typeof (value as Partial<StudioRecoveryRecord>).baseDiskVersion !== "string"
+    || typeof (value as Partial<StudioRecoveryRecord>).draftSource !== "string"
+    || !Number.isSafeInteger((value as Partial<StudioRecoveryRecord>).revision)
+    || typeof (value as Partial<StudioRecoveryRecord>).writtenAt !== "string"
+    || typeof (value as Partial<StudioRecoveryRecord>).checksum !== "string"
+  ) {
+    throw new Error("Invalid Scribe Studio recovery record.");
+  }
+  const record = value as StudioRecoveryRecord;
+  if (record.checksum !== checksum(record)) throw new Error("Scribe Studio recovery checksum mismatch.");
+  return record;
+}
+
+function checksum(input: Pick<StudioRecoveryRecord, "sourcePath" | "baseDiskVersion" | "draftSource" | "revision">): string {
+  return createHash("sha256")
+    .update(input.sourcePath)
+    .update("\0")
+    .update(input.baseDiskVersion)
+    .update("\0")
+    .update(String(input.revision))
+    .update("\0")
+    .update(input.draftSource)
+    .digest("hex");
+}
+
+async function durableJsonWrite(path: string, value: unknown): Promise<void> {
+  const directory = dirname(path);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const temporary = `${path}.${process.pid}-${randomBytes(8).toString("hex")}.tmp`;
+  let exists = false;
+  try {
+    const handle = await open(temporary, "wx", 0o600);
+    exists = true;
+    try {
+      await handle.writeFile(`${JSON.stringify(value)}\n`, "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await rename(temporary, path);
+    exists = false;
+    await syncDirectory(directory);
+  } finally {
+    if (exists) await unlink(temporary).catch(() => undefined);
+  }
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  const directory = await open(path, "r");
+  try {
+    await directory.sync();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (platform() !== "win32" || (code !== "EINVAL" && code !== "ENOTSUP" && code !== "EPERM")) throw error;
+  } finally {
+    await directory.close();
+  }
+}

--- a/packages/cli/src/studio-security.test.ts
+++ b/packages/cli/src/studio-security.test.ts
@@ -1,0 +1,48 @@
+import type { IncomingMessage } from "node:http";
+
+import { expect, it } from "vitest";
+
+import { authorizeStudioMutation, createStudioSession, studioSessionHeader } from "./studio-security.js";
+
+function request(headers: Record<string, string>): IncomingMessage {
+  return { headers } as IncomingMessage;
+}
+
+it("accepts only the process capability on the matching local origin and host", () => {
+  const session = createStudioSession();
+  session.origin = "http://127.0.0.1:4317";
+
+  expect(authorizeStudioMutation(request({
+    [studioSessionHeader()]: session.token,
+    "content-type": "application/json; charset=utf-8",
+    origin: session.origin,
+    host: "127.0.0.1:4317",
+    "sec-fetch-site": "same-origin"
+  }), session)).toBeUndefined();
+});
+
+it("rejects missing capabilities, cross-site requests, and mismatched origins", () => {
+  const session = createStudioSession();
+  session.origin = "http://127.0.0.1:4317";
+  const base = {
+    [studioSessionHeader()]: session.token,
+    "content-type": "application/json",
+    host: "127.0.0.1:4317"
+  };
+
+  expect(authorizeStudioMutation(request({ ...base, [studioSessionHeader()]: "wrong" }), session)).toContain("capability");
+  expect(authorizeStudioMutation(request({ ...base, "sec-fetch-site": "cross-site" }), session)).toContain("Cross-site");
+  expect(authorizeStudioMutation(request({ ...base, origin: "http://attacker.invalid" }), session)).toContain("origin");
+  expect(authorizeStudioMutation(request({ ...base, host: "127.0.0.1:9999" }), session)).toContain("host");
+});
+
+it("requires JSON so ordinary cross-site form posts cannot mutate Studio", () => {
+  const session = createStudioSession();
+  session.origin = "http://127.0.0.1:4317";
+
+  expect(authorizeStudioMutation(request({
+    [studioSessionHeader()]: session.token,
+    "content-type": "application/x-www-form-urlencoded",
+    host: "127.0.0.1:4317"
+  }), session)).toContain("application/json");
+});

--- a/packages/cli/src/studio-security.ts
+++ b/packages/cli/src/studio-security.ts
@@ -1,0 +1,53 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import type { IncomingMessage } from "node:http";
+
+const sessionHeader = "x-scribe-studio-session";
+
+export interface StudioSession {
+  readonly token: string;
+  origin?: string;
+}
+
+export function createStudioSession(): StudioSession {
+  return { token: randomBytes(32).toString("base64url") };
+}
+
+export function authorizeStudioMutation(request: IncomingMessage, session: StudioSession): string | undefined {
+  const suppliedToken = request.headers[sessionHeader];
+  if (typeof suppliedToken !== "string" || !safeEqual(suppliedToken, session.token)) {
+    return "This Studio mutation is missing a valid session capability.";
+  }
+
+  const contentType = request.headers["content-type"];
+  if (typeof contentType !== "string" || !contentType.toLowerCase().startsWith("application/json")) {
+    return "Studio mutations require Content-Type: application/json.";
+  }
+
+  if (request.headers["sec-fetch-site"] === "cross-site") {
+    return "Cross-site Studio mutations are not allowed.";
+  }
+
+  const origin = request.headers.origin;
+  if (origin !== undefined && session.origin !== undefined && origin !== session.origin) {
+    return "The Studio mutation origin does not match this local session.";
+  }
+
+  if (session.origin !== undefined) {
+    const expectedHost = new URL(session.origin).host;
+    if (request.headers.host !== expectedHost) {
+      return "The Studio mutation host does not match this local session.";
+    }
+  }
+
+  return undefined;
+}
+
+export function studioSessionHeader(): string {
+  return sessionHeader;
+}
+
+function safeEqual(left: string, right: string): boolean {
+  const leftBytes = Buffer.from(left);
+  const rightBytes = Buffer.from(right);
+  return leftBytes.length === rightBytes.length && timingSafeEqual(leftBytes, rightBytes);
+}

--- a/packages/cli/src/studio-transactions.test.ts
+++ b/packages/cli/src/studio-transactions.test.ts
@@ -85,6 +85,34 @@ it("runs system mutations in the same queue as client mutations", async () => {
   expect(order).toEqual(["external"]);
 });
 
+it("reserves the revision that a queued client observes during a system mutation", async () => {
+  const coordinator = new StudioTransactionCoordinator(1);
+  let releaseSystem!: () => void;
+  let exposeRevision!: (revision: number) => void;
+  const systemBlocked = new Promise<void>((resolve) => {
+    releaseSystem = resolve;
+  });
+  const revisionExposed = new Promise<number>((resolve) => {
+    exposeRevision = resolve;
+  });
+
+  const system = coordinator.system(async (nextRevision) => {
+    exposeRevision(nextRevision);
+    await systemBlocked;
+    return { changed: true as const, value: "external" };
+  });
+  const observedRevision = await revisionExposed;
+  const client = coordinator.mutate(
+    { clientId: "tab-a", operationId: "a-2", baseRevision: observedRevision },
+    async () => ({ accepted: true as const, value: "preserved browser draft" })
+  );
+
+  releaseSystem();
+
+  await expect(system).resolves.toEqual({ changed: true, revision: 2, value: "external" });
+  await expect(client).resolves.toEqual({ kind: "accepted", revision: 3, value: "preserved browser draft" });
+});
+
 it("does not advance the revision for a no-op system observation", async () => {
   const coordinator = new StudioTransactionCoordinator(7);
 

--- a/packages/cli/src/studio-transactions.test.ts
+++ b/packages/cli/src/studio-transactions.test.ts
@@ -64,6 +64,23 @@ it("does not advance the revision when a guarded mutation is rejected", async ()
   expect(coordinator.revision).toBe(2);
 });
 
+it("evicts failed operation ids so an explicit retry can execute", async () => {
+  const coordinator = new StudioTransactionCoordinator(1);
+  const request = { clientId: "tab-a", operationId: "a-retry", baseRevision: 1 };
+  let attempts = 0;
+
+  await expect(coordinator.mutate(request, async () => {
+    attempts += 1;
+    throw new Error("transient compilation failure");
+  })).rejects.toThrow("transient compilation failure");
+
+  await expect(coordinator.mutate(request, async () => {
+    attempts += 1;
+    return { accepted: true as const, value: "recovered" };
+  })).resolves.toEqual({ kind: "accepted", revision: 2, value: "recovered" });
+  expect(attempts).toBe(2);
+});
+
 it("runs system mutations in the same queue as client mutations", async () => {
   const coordinator = new StudioTransactionCoordinator(1);
   const order: string[] = [];

--- a/packages/cli/src/studio-transactions.test.ts
+++ b/packages/cli/src/studio-transactions.test.ts
@@ -1,0 +1,102 @@
+import { expect, it } from "vitest";
+
+import { StudioTransactionCoordinator } from "./studio-transactions.js";
+
+it("serializes concurrent mutations and rejects the stale second writer", async () => {
+  const coordinator = new StudioTransactionCoordinator(1);
+  const applied: string[] = [];
+  let releaseFirst!: () => void;
+  const firstBlocked = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+
+  const first = coordinator.mutate(
+    { clientId: "tab-a", operationId: "a-1", baseRevision: 1 },
+    async () => {
+      await firstBlocked;
+      applied.push("first");
+      return { accepted: true as const, value: "first" };
+    }
+  );
+  const second = coordinator.mutate(
+    { clientId: "tab-b", operationId: "b-1", baseRevision: 1 },
+    async () => {
+      applied.push("second");
+      return { accepted: true as const, value: "second" };
+    }
+  );
+
+  releaseFirst();
+
+  await expect(first).resolves.toEqual({ kind: "accepted", revision: 2, value: "first" });
+  await expect(second).resolves.toEqual({ kind: "stale", revision: 2 });
+  expect(applied).toEqual(["first"]);
+});
+
+it("returns an accepted operation idempotently without applying it twice", async () => {
+  const coordinator = new StudioTransactionCoordinator(4);
+  let applications = 0;
+  const request = { clientId: "tab-a", operationId: "a-7", baseRevision: 4 };
+
+  const first = await coordinator.mutate(request, async () => {
+    applications += 1;
+    return { accepted: true as const, value: { source: "# accepted" } };
+  });
+  const replay = await coordinator.mutate(request, async () => {
+    applications += 1;
+    return { accepted: true as const, value: { source: "# duplicate" } };
+  });
+
+  expect(first).toEqual({ kind: "accepted", revision: 5, value: { source: "# accepted" } });
+  expect(replay).toEqual(first);
+  expect(applications).toBe(1);
+});
+
+it("does not advance the revision when a guarded mutation is rejected", async () => {
+  const coordinator = new StudioTransactionCoordinator(2);
+
+  const result = await coordinator.mutate(
+    { clientId: "tab-a", operationId: "a-2", baseRevision: 2 },
+    async () => ({ accepted: false as const, value: "protected source changed" })
+  );
+
+  expect(result).toEqual({ kind: "rejected", revision: 2, value: "protected source changed" });
+  expect(coordinator.revision).toBe(2);
+});
+
+it("runs system mutations in the same queue as client mutations", async () => {
+  const coordinator = new StudioTransactionCoordinator(1);
+  const order: string[] = [];
+
+  const system = coordinator.system(async () => {
+    order.push("external");
+    return { changed: true, value: "external" };
+  });
+  const client = coordinator.mutate(
+    { clientId: "tab-a", operationId: "a-1", baseRevision: 1 },
+    async () => {
+      order.push("client");
+      return { accepted: true as const, value: "client" };
+    }
+  );
+
+  await expect(system).resolves.toEqual({ changed: true, revision: 2, value: "external" });
+  await expect(client).resolves.toEqual({ kind: "stale", revision: 2 });
+  expect(order).toEqual(["external"]);
+});
+
+it("does not advance the revision for a no-op system observation", async () => {
+  const coordinator = new StudioTransactionCoordinator(7);
+
+  const system = await coordinator.system(async () => ({
+    changed: false as const,
+    value: "same file bytes"
+  }));
+
+  expect(system).toEqual({ changed: false, revision: 7, value: "same file bytes" });
+  expect(coordinator.revision).toBe(7);
+  await expect(coordinator.mutate(
+    { clientId: "tab-a", operationId: "a-8", baseRevision: 7 },
+    async () => ({ accepted: true as const, value: "edit" })
+  )).resolves.toEqual({ kind: "accepted", revision: 8, value: "edit" });
+});

--- a/packages/cli/src/studio-transactions.ts
+++ b/packages/cli/src/studio-transactions.ts
@@ -53,11 +53,12 @@ export class StudioTransactionCoordinator {
   }
 
   system<T>(
-    operation: () => Promise<{ readonly changed: boolean; readonly value: T }>
+    operation: (nextRevision: number) => Promise<{ readonly changed: boolean; readonly value: T }>
   ): Promise<{ readonly changed: boolean; readonly revision: number; readonly value: T }> {
     return this.#enqueue(async () => {
-      const result = await operation();
-      if (result.changed) this.#revision += 1;
+      const nextRevision = this.#revision + 1;
+      const result = await operation(nextRevision);
+      if (result.changed) this.#revision = nextRevision;
       return { changed: result.changed, revision: this.#revision, value: result.value };
     });
   }

--- a/packages/cli/src/studio-transactions.ts
+++ b/packages/cli/src/studio-transactions.ts
@@ -1,0 +1,78 @@
+export interface StudioMutationRequest {
+  readonly clientId: string;
+  readonly operationId: string;
+  readonly baseRevision: number;
+}
+
+export type StudioMutationDecision<T> =
+  | { readonly accepted: true; readonly value: T }
+  | { readonly accepted: false; readonly value: T };
+
+export type StudioMutationResult<T> =
+  | { readonly kind: "accepted"; readonly revision: number; readonly value: T }
+  | { readonly kind: "rejected"; readonly revision: number; readonly value: T }
+  | { readonly kind: "stale"; readonly revision: number };
+
+const retainedOperationLimit = 2_048;
+
+export class StudioTransactionCoordinator {
+  readonly #operations = new Map<string, Promise<StudioMutationResult<unknown>>>();
+  #tail: Promise<void> = Promise.resolve();
+  #revision: number;
+
+  constructor(initialRevision: number) {
+    this.#revision = initialRevision;
+  }
+
+  get revision(): number {
+    return this.#revision;
+  }
+
+  mutate<T>(
+    request: StudioMutationRequest,
+    operation: () => Promise<StudioMutationDecision<T>>
+  ): Promise<StudioMutationResult<T>> {
+    const key = `${request.clientId}\0${request.operationId}`;
+    const existing = this.#operations.get(key);
+    if (existing !== undefined) return existing as Promise<StudioMutationResult<T>>;
+
+    const result = this.#enqueue(async (): Promise<StudioMutationResult<T>> => {
+      if (request.baseRevision !== this.#revision) {
+        return { kind: "stale", revision: this.#revision };
+      }
+      const decision = await operation();
+      if (!decision.accepted) {
+        return { kind: "rejected", revision: this.#revision, value: decision.value };
+      }
+      this.#revision += 1;
+      return { kind: "accepted", revision: this.#revision, value: decision.value };
+    });
+    this.#operations.set(key, result as Promise<StudioMutationResult<unknown>>);
+    this.#trimOperations();
+    return result;
+  }
+
+  system<T>(
+    operation: () => Promise<{ readonly changed: boolean; readonly value: T }>
+  ): Promise<{ readonly changed: boolean; readonly revision: number; readonly value: T }> {
+    return this.#enqueue(async () => {
+      const result = await operation();
+      if (result.changed) this.#revision += 1;
+      return { changed: result.changed, revision: this.#revision, value: result.value };
+    });
+  }
+
+  #enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.#tail.then(operation, operation);
+    this.#tail = result.then(() => undefined, () => undefined);
+    return result;
+  }
+
+  #trimOperations(): void {
+    while (this.#operations.size > retainedOperationLimit) {
+      const oldest = this.#operations.keys().next().value as string | undefined;
+      if (oldest === undefined) return;
+      this.#operations.delete(oldest);
+    }
+  }
+}

--- a/packages/cli/src/studio-transactions.ts
+++ b/packages/cli/src/studio-transactions.ts
@@ -47,7 +47,11 @@ export class StudioTransactionCoordinator {
       this.#revision += 1;
       return { kind: "accepted", revision: this.#revision, value: decision.value };
     });
-    this.#operations.set(key, result as Promise<StudioMutationResult<unknown>>);
+    const cached = result as Promise<StudioMutationResult<unknown>>;
+    this.#operations.set(key, cached);
+    void cached.catch(() => {
+      if (this.#operations.get(key) === cached) this.#operations.delete(key);
+    });
     this.#trimOperations();
     return result;
   }

--- a/packages/cli/src/studio-ui.test.ts
+++ b/packages/cli/src/studio-ui.test.ts
@@ -16,6 +16,11 @@ it("ships the constrained Rich Text client and the Studio visual tokens", () => 
   expect(client).toContain("Math.max(studioRevision, body.revision)");
   expect(client).toContain("next.revision < studioRevision");
   expect(client).toContain("Your browser recovery draft remains intact");
+  expect(client).toContain("transaction.onabort = () => reject(transaction.error)");
+  expect(client).toContain("const [writer, setWriter] = useState(null)");
+  expect(client).toContain("writer === false");
+  expect(client).toContain('if (!response.ok || typeof body.source !== "string")');
+  expect(client).not.toContain("revision: revisionRef.current");
   expect(client).not.toContain('aria-label="Markdown formatting"');
 
   const styles = studioStyles();

--- a/packages/cli/src/studio-ui.test.ts
+++ b/packages/cli/src/studio-ui.test.ts
@@ -1,0 +1,24 @@
+import { expect, it } from "vitest";
+
+import { studioClientModule, studioStyles, type StudioClientImports } from "./studio-ui.js";
+
+it("ships the constrained Rich Text client and the Studio visual tokens", () => {
+  const client = studioClientModule({} as StudioClientImports);
+  expect(client).toContain("MDXEditor");
+  expect(client).toContain("lucide-react");
+  expect(client).toContain("Scribe Studio");
+  expect(client).toContain("Rich Text");
+  expect(client).toContain("format_align_left: AlignLeft");
+  expect(client).toContain("format_align_center: AlignCenter");
+  expect(client).toContain("format_align_right: AlignRight");
+  expect(client).toContain('new EventSource("/__scribe/api/events")');
+  expect(client).toContain("scribe-studio-recovery");
+  expect(client).toContain("Math.max(studioRevision, body.revision)");
+  expect(client).toContain("next.revision < studioRevision");
+  expect(client).toContain("Your browser recovery draft remains intact");
+  expect(client).not.toContain('aria-label="Markdown formatting"');
+
+  const styles = studioStyles();
+  expect(styles).toContain("#CDFF57");
+  expect(styles).toContain("#0A0A0A");
+});

--- a/packages/cli/src/studio-ui.ts
+++ b/packages/cli/src/studio-ui.ts
@@ -213,13 +213,14 @@ async function clearBrowserRecovery(key) {
     transaction.objectStore(recoveryStoreName).delete(key);
     transaction.oncomplete = () => resolve();
     transaction.onerror = () => reject(transaction.error);
+    transaction.onabort = () => reject(transaction.error);
   });
 }
 
 function Status({ state, richError, writer, connected }) {
   const hasErrors = richError || state.diagnostics.some((item) => item.severity === "error");
-  const kind = !connected ? "error" : !writer ? "conflict" : state.conflict ? "conflict" : hasErrors ? "error" : state.dirty ? "dirty" : "ready";
-  const label = !connected ? "Reconnecting" : !writer ? "Read-only tab" : state.conflict ? "External change" : richError ? "Rich edit rejected" : hasErrors ? "Compilation blocked" : state.dirty ? "Unsaved draft" : "Ready";
+  const kind = !connected ? "error" : writer === false ? "conflict" : state.conflict ? "conflict" : hasErrors ? "error" : state.dirty ? "dirty" : "ready";
+  const label = !connected ? "Reconnecting" : writer === false ? "Read-only tab" : state.conflict ? "External change" : richError ? "Rich edit rejected" : hasErrors ? "Compilation blocked" : state.dirty ? "Unsaved draft" : "Ready";
   return <div className="studio-status" data-status={kind} role="status"><span className="studio-status__dot" aria-hidden="true" /><span id="status-text">{label}</span></div>;
 }
 
@@ -234,7 +235,7 @@ function MarkdownPanel({ state, source, setSource, textareaRef, writer }) {
   const diagnostics = formatDiagnostics(state.diagnostics);
   return <section className="studio-panel source-panel" aria-label="Markdown editor">
     <PanelHeading icon={FileText} title="Markdown" state={state.conflict ? "Conflict" : state.dirty ? "Unsaved" : "Saved"} />
-    <textarea ref={textareaRef} id="source" className="source-textarea" value={source} onChange={(event) => setSource(event.target.value)} readOnly={!writer} spellCheck="false" aria-label={writer ? "Article source" : "Article source (read-only in this tab)"} data-lenis-prevent />
+    <textarea ref={textareaRef} id="source" className="source-textarea" value={source} onChange={(event) => setSource(event.target.value)} readOnly={writer === false} spellCheck="false" aria-label={writer === false ? "Article source (read-only in this tab)" : "Article source"} data-lenis-prevent />
     {diagnostics && <pre id="diagnostics" className="diagnostics" aria-live="polite">{diagnostics}</pre>}
   </section>;
 }
@@ -370,7 +371,6 @@ function RichEditor({ session, state, onAccepted, onRejected, onEditInMarkdown, 
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           source: candidate,
-          revision: revisionRef.current,
           baseSource: session.baseSource,
           baseDiskVersion: session.baseDiskVersion
         })
@@ -494,7 +494,7 @@ function StudioApp() {
   const [theme, setTheme] = useState("dark");
   const [copyStatus, setCopyStatus] = useState("");
   const [richPending, setRichPending] = useState(false);
-  const [writer, setWriter] = useState(false);
+  const [writer, setWriter] = useState(null);
   const [connected, setConnected] = useState(true);
   const diskVersion = useRef("");
   const draftBaseDiskVersion = useRef("");
@@ -741,7 +741,7 @@ function StudioApp() {
   }, [state, source, apply]);
 
   const enterRich = useCallback(async () => {
-    if (!writer) {
+    if (writer === false) {
       toast.error("Another Studio tab currently owns this draft.");
       return;
     }
@@ -804,7 +804,7 @@ function StudioApp() {
   }, [state?.recoveryKey]);
 
   const save = useCallback(async () => {
-    if (!state || !writer) {
+    if (!state || writer === false) {
       toast.error("This tab is read-only while another Studio tab owns the draft.");
       return;
     }
@@ -859,7 +859,11 @@ function StudioApp() {
     toast.success("Recovered the discarded draft");
   };
   const discard = async () => {
-    const { body } = await request("/__scribe/api/discard", { method: "POST", body: "{}" });
+    const { response, body } = await request("/__scribe/api/discard", { method: "POST", body: "{}" });
+    if (!response.ok || typeof body.source !== "string") {
+      toast.error(body.error || "The source could not be reloaded from disk.");
+      return;
+    }
     apply(body, true);
     setAuthorModeState("markdown");
     setRichSession(null);
@@ -875,7 +879,7 @@ function StudioApp() {
       <Status state={state} richError={richError} writer={writer} connected={connected} />
       <div className="studio-actions">
         {(state.diagnostics.length > 0 || richError) && <Hint label="Copy diagnostics"><Button id="copy-diagnostics" type="button" size="icon" variant="ghost" aria-label="Copy diagnostics" onClick={copyDiagnostics}><ClipboardCopy aria-hidden="true" /></Button></Hint>}
-        <Button id="save" type="button" variant="default" onClick={save} disabled={!writer}><Save data-icon="inline-start" aria-hidden="true" />Save <kbd>⌘S</kbd></Button>
+        <Button id="save" type="button" variant="default" onClick={save} disabled={writer === false}><Save data-icon="inline-start" aria-hidden="true" />Save <kbd>⌘S</kbd></Button>
       </div>
     </header>
 

--- a/packages/cli/src/studio-ui.ts
+++ b/packages/cli/src/studio-ui.ts
@@ -98,16 +98,128 @@ function formatDiagnostics(items) {
   }).join("\n");
 }
 
-async function request(path, options) {
-  const response = await fetch(path, options);
-  const body = await response.json();
-  return { response, body };
+const studioSessionToken = document.querySelector('meta[name="scribe-studio-session"]')?.content || "";
+const studioClientId = crypto.randomUUID();
+let studioRevision = 0;
+let studioOperation = 0;
+let studioMutationTail = Promise.resolve();
+
+async function performRequest(path, options = {}) {
+  try {
+    const response = await fetch(path, options);
+    const text = await response.text();
+    let body;
+    try {
+      body = text ? JSON.parse(text) : {};
+    } catch {
+      body = { error: "Studio received an invalid response from its local server." };
+    }
+    if (Number.isSafeInteger(body.revision)) studioRevision = Math.max(studioRevision, body.revision);
+    return { response, body };
+  } catch {
+    return {
+      response: new Response(null, { status: 503, statusText: "Studio server unavailable" }),
+      body: { error: "Studio could not reach its local server. Your browser recovery draft remains intact." }
+    };
+  }
 }
 
-function Status({ state, richError }) {
+function request(path, options = {}) {
+  const method = (options.method || "GET").toUpperCase();
+  if (method !== "PUT" && method !== "POST") return performRequest(path, options);
+  if (path === "/__scribe/api/lease") {
+    return performRequest(path, {
+      ...options,
+      headers: {
+        ...options.headers,
+        "content-type": "application/json",
+        "x-scribe-studio-session": studioSessionToken
+      },
+      body: JSON.stringify({ clientId: studioClientId })
+    });
+  }
+
+  const execute = async () => {
+    const supplied = options.body ? JSON.parse(options.body) : {};
+    const body = JSON.stringify({
+      ...supplied,
+      clientId: studioClientId,
+      operationId: studioClientId + "-" + (++studioOperation),
+      baseRevision: studioRevision
+    });
+    return performRequest(path, {
+      ...options,
+      headers: {
+        ...options.headers,
+        "content-type": "application/json",
+        "x-scribe-studio-session": studioSessionToken
+      },
+      body
+    });
+  };
+  const result = studioMutationTail.then(execute, execute);
+  studioMutationTail = result.then(() => undefined, () => undefined);
+  return result;
+}
+
+const recoveryDatabaseName = "scribe-studio-recovery";
+const recoveryStoreName = "drafts";
+let recoveryDatabasePromise;
+
+async function recoveryDatabase() {
+  recoveryDatabasePromise ??= new Promise((resolve, reject) => {
+    const opening = indexedDB.open(recoveryDatabaseName, 1);
+    opening.onupgradeneeded = () => opening.result.createObjectStore(recoveryStoreName);
+    opening.onsuccess = () => {
+      opening.result.onversionchange = () => {
+        opening.result.close();
+        recoveryDatabasePromise = undefined;
+      };
+      resolve(opening.result);
+    };
+    opening.onerror = () => {
+      recoveryDatabasePromise = undefined;
+      reject(opening.error);
+    };
+  });
+  return recoveryDatabasePromise;
+}
+
+async function readBrowserRecovery(key) {
+  const database = await recoveryDatabase();
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(recoveryStoreName, "readonly");
+    const request = transaction.objectStore(recoveryStoreName).get(key);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function writeBrowserRecovery(key, value) {
+  const database = await recoveryDatabase();
+  await new Promise((resolve, reject) => {
+    const transaction = database.transaction(recoveryStoreName, "readwrite");
+    transaction.objectStore(recoveryStoreName).put(value, key);
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+    transaction.onabort = () => reject(transaction.error);
+  });
+}
+
+async function clearBrowserRecovery(key) {
+  const database = await recoveryDatabase();
+  await new Promise((resolve, reject) => {
+    const transaction = database.transaction(recoveryStoreName, "readwrite");
+    transaction.objectStore(recoveryStoreName).delete(key);
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+  });
+}
+
+function Status({ state, richError, writer, connected }) {
   const hasErrors = richError || state.diagnostics.some((item) => item.severity === "error");
-  const kind = state.conflict ? "conflict" : hasErrors ? "error" : state.dirty ? "dirty" : "ready";
-  const label = state.conflict ? "External change" : richError ? "Rich edit rejected" : hasErrors ? "Compilation blocked" : state.dirty ? "Unsaved draft" : "Ready";
+  const kind = !connected ? "error" : !writer ? "conflict" : state.conflict ? "conflict" : hasErrors ? "error" : state.dirty ? "dirty" : "ready";
+  const label = !connected ? "Reconnecting" : !writer ? "Read-only tab" : state.conflict ? "External change" : richError ? "Rich edit rejected" : hasErrors ? "Compilation blocked" : state.dirty ? "Unsaved draft" : "Ready";
   return <div className="studio-status" data-status={kind} role="status"><span className="studio-status__dot" aria-hidden="true" /><span id="status-text">{label}</span></div>;
 }
 
@@ -118,11 +230,11 @@ function PanelHeading({ icon: Icon, title, state, tabs }) {
   </div>;
 }
 
-function MarkdownPanel({ state, source, setSource, textareaRef }) {
+function MarkdownPanel({ state, source, setSource, textareaRef, writer }) {
   const diagnostics = formatDiagnostics(state.diagnostics);
   return <section className="studio-panel source-panel" aria-label="Markdown editor">
     <PanelHeading icon={FileText} title="Markdown" state={state.conflict ? "Conflict" : state.dirty ? "Unsaved" : "Saved"} />
-    <textarea ref={textareaRef} id="source" className="source-textarea" value={source} onChange={(event) => setSource(event.target.value)} spellCheck="false" aria-label="Article source" data-lenis-prevent />
+    <textarea ref={textareaRef} id="source" className="source-textarea" value={source} onChange={(event) => setSource(event.target.value)} readOnly={!writer} spellCheck="false" aria-label={writer ? "Article source" : "Article source (read-only in this tab)"} data-lenis-prevent />
     {diagnostics && <pre id="diagnostics" className="diagnostics" aria-live="polite">{diagnostics}</pre>}
   </section>;
 }
@@ -134,7 +246,7 @@ const previewPresets = {
 };
 
 function PreviewPanel({ theme, viewport, previewVersion, compact = false }) {
-  const src = "/preview?theme=" + theme + "&version=" + previewVersion;
+  const src = "/preview?theme=" + theme;
   const preset = previewPresets[viewport];
   const stageRef = useRef(null);
   const [scale, setScale] = useState(1);
@@ -222,7 +334,7 @@ function RichToolbar() {
   </div>;
 }
 
-function RichEditor({ session, state, onAccepted, onRejected, onEditInMarkdown, onPendingChange, registerFlush }) {
+function RichEditor({ session, state, onAccepted, onRejected, onEditInMarkdown, onPendingChange, onRecoveryCandidate, registerFlush }) {
   const editorRef = useRef(null);
   const revisionRef = useRef(session.revision);
   const lastAcceptedRef = useRef(session.projectionMarkdown);
@@ -256,13 +368,24 @@ function RichEditor({ session, state, onAccepted, onRejected, onEditInMarkdown, 
       const { response, body } = await request("/__scribe/api/rich-draft", {
         method: "PUT",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ source: candidate, revision: revisionRef.current })
+        body: JSON.stringify({
+          source: candidate,
+          revision: revisionRef.current,
+          baseSource: session.baseSource,
+          baseDiskVersion: session.baseDiskVersion
+        })
       });
       if (response.ok) {
         revisionRef.current = body.revision;
         lastAcceptedRef.current = candidate;
         pendingRef.current = false;
-        onAccepted(body, { ...session, revision: body.revision, projectionMarkdown: body.projectionMarkdown, islands: body.islands });
+        onAccepted(body, {
+          ...session,
+          revision: body.revision,
+          projectionMarkdown: body.projectionMarkdown,
+          islands: body.islands,
+          baseSource: body.source
+        });
         return true;
       }
       editorRef.current?.setMarkdown(lastAcceptedRef.current);
@@ -304,9 +427,10 @@ function RichEditor({ session, state, onAccepted, onRejected, onEditInMarkdown, 
     if (initialNormalize) return;
     pendingRef.current = true;
     onPendingChange(true);
+    onRecoveryCandidate(candidate, session);
     clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => submit(candidate), 320);
-  }, [onPendingChange, submit]);
+  }, [onPendingChange, onRecoveryCandidate, session, submit]);
 
   return <RichContext.Provider value={{ islands: session.islands, editInMarkdown: onEditInMarkdown }}>
     <section className="studio-panel rich-panel" aria-label="Rich Text editor">
@@ -343,15 +467,15 @@ function SecondaryPane({ tab, setTab, source, state, theme, viewport }) {
   </section>;
 }
 
-function Workspace({ authorMode, state, source, setSource, textareaRef, theme, viewport, richSession, setRichSession, richError, setRichError, setAuthorMode, setRichPending, registerRichFlush, revealProtected }) {
+function Workspace({ authorMode, state, source, setSource, textareaRef, theme, viewport, richSession, setRichSession, richError, setRichError, setAuthorMode, setRichPending, preserveRichCandidate, registerRichFlush, revealProtected, writer }) {
   if (authorMode === "markdown") {
     return <div className="studio-workspace studio-workspace--markdown">
-      <MarkdownPanel state={state} source={source} setSource={setSource} textareaRef={textareaRef} />
+      <MarkdownPanel state={state} source={source} setSource={setSource} textareaRef={textareaRef} writer={writer} />
       <PreviewPanel theme={theme} viewport={viewport} previewVersion={state.previewVersion} />
     </div>;
   }
   return <div className="studio-workspace studio-workspace--rich">
-    <RichEditor session={richSession} state={state} registerFlush={registerRichFlush} onPendingChange={setRichPending} onEditInMarkdown={revealProtected} onRejected={(message) => { setRichError(message); toast.error(message); }} onAccepted={(body, nextSession, applyState = true) => {
+    <RichEditor session={richSession} state={state} registerFlush={registerRichFlush} onPendingChange={setRichPending} onRecoveryCandidate={preserveRichCandidate} onEditInMarkdown={revealProtected} onRejected={(message) => { setRichError(message); toast.error(message); }} onAccepted={(body, nextSession, applyState = true) => {
       setRichError("");
       setRichSession(nextSession);
       if (applyState) setAuthorMode(body);
@@ -370,35 +494,212 @@ function StudioApp() {
   const [theme, setTheme] = useState("dark");
   const [copyStatus, setCopyStatus] = useState("");
   const [richPending, setRichPending] = useState(false);
+  const [writer, setWriter] = useState(false);
+  const [connected, setConnected] = useState(true);
   const diskVersion = useRef("");
+  const draftBaseDiskVersion = useRef("");
   const textareaRef = useRef(null);
   const updateTimer = useRef();
   const richFlushRef = useRef(null);
   const pendingSelection = useRef(null);
+  const sourceRef = useRef("");
+  const serverSourceRef = useRef("");
+  const browserRecoveryReady = useRef(false);
+  const browserRecoveryConflict = useRef(false);
+  const browserRecoveryWarningShown = useRef(false);
+  const richPendingRef = useRef(false);
 
   const apply = useCallback((next, replaceSource = false) => {
+    if (Number.isSafeInteger(next.revision) && next.revision < studioRevision) return false;
     diskVersion.current = next.diskVersion;
+    if (!draftBaseDiskVersion.current || !next.dirty) draftBaseDiskVersion.current = next.diskVersion;
+    serverSourceRef.current = next.source;
     setState(next);
-    if (replaceSource) setSource(next.source);
+    if (replaceSource) {
+      sourceRef.current = next.source;
+      setSource(next.source);
+    }
+    return true;
+  }, []);
+
+  const updateSource = useCallback((next) => {
+    sourceRef.current = next;
+    setSource(next);
   }, []);
 
   const applyRichState = useCallback((body) => apply(body, true), [apply]);
 
   useEffect(() => {
-    request("/__scribe/api/document").then(({ body }) => apply(body, true));
-    const interval = setInterval(async () => {
-      const { body } = await request("/__scribe/api/document");
-      if (body.diskVersion !== diskVersion.current || body.conflict) apply(body, !body.dirty);
-    }, 900);
-    return () => clearInterval(interval);
+    let active = true;
+    let events;
+    const openDocument = async () => {
+      const { response, body } = await request("/__scribe/api/document");
+      if (!response.ok || typeof body.source !== "string") {
+        if (active) {
+          setConnected(false);
+          toast.error(body.error || "Studio could not load the local document.");
+        }
+        return false;
+      }
+      apply(body, true);
+      try {
+        const recovered = await readBrowserRecovery(body.recoveryKey);
+        if (
+          recovered?.kind === "rich"
+          && typeof recovered.candidate === "string"
+          && typeof recovered.baseSource === "string"
+          && typeof recovered.diskVersion === "string"
+        ) {
+          draftBaseDiskVersion.current = recovered.diskVersion;
+          const restored = await request("/__scribe/api/rich-draft", {
+            method: "PUT",
+            body: JSON.stringify({
+              source: recovered.candidate,
+              baseSource: recovered.baseSource,
+              baseDiskVersion: recovered.diskVersion
+            })
+          });
+          if (restored.response.ok && typeof restored.body.source === "string") {
+            apply(restored.body, true);
+            await clearBrowserRecovery(body.recoveryKey);
+            toast.warning("Recovered Rich Text typing that had not reached the Studio server.");
+          } else {
+            toast.error(restored.body.error || "Studio preserved a Rich Text recovery candidate but could not restore it safely.");
+          }
+        } else
+        if (
+          recovered
+          && typeof recovered.source === "string"
+          && recovered.source !== body.source
+        ) {
+          draftBaseDiskVersion.current = recovered.diskVersion;
+          sourceRef.current = recovered.source;
+          setSource(recovered.source);
+          browserRecoveryConflict.current = recovered.diskVersion !== body.diskVersion;
+          toast.warning(recovered.diskVersion === body.diskVersion
+            ? "Recovered typing that had not reached the Studio server."
+            : "Recovered local typing, but the source also changed on disk. Saving is blocked until you reconcile.");
+        }
+      } catch {
+        if (!browserRecoveryWarningShown.current) {
+          browserRecoveryWarningShown.current = true;
+          toast.warning("Instant browser crash recovery is unavailable. Drafts are still protected after they reach the local Studio server.");
+        }
+      } finally {
+        browserRecoveryReady.current = true;
+      }
+      if (body.recovered) {
+        toast.warning(body.recoveryConflict
+          ? "Recovered an unsaved draft, but the source also changed on disk. Reconcile before saving."
+          : "Recovered your unsaved Studio draft.");
+      }
+      return true;
+    };
+    const refresh = async () => {
+      const { response, body } = await request("/__scribe/api/document");
+      if (!response.ok || typeof body.source !== "string") {
+        if (active) setConnected(false);
+        return;
+      }
+      if (richPendingRef.current) return;
+      if (body.diskVersion !== diskVersion.current) {
+        const localPending = sourceRef.current !== serverSourceRef.current;
+        if (localPending) {
+          const preserved = await request("/__scribe/api/draft", {
+            method: "PUT",
+            body: JSON.stringify({
+              source: sourceRef.current,
+              externalConflict: true,
+              baseDiskVersion: draftBaseDiskVersion.current
+            })
+          });
+          if (typeof preserved.body.source === "string") apply(preserved.body, false);
+          return;
+        }
+        apply(body, !body.dirty);
+      } else if (body.conflict) {
+        apply(body, !body.dirty);
+      }
+    };
+    void openDocument().then((opened) => {
+      if (!active || !opened) return;
+      events = new EventSource("/__scribe/api/events");
+      events.onopen = () => setConnected(true);
+      events.onerror = () => setConnected(false);
+      events.onmessage = () => void refresh();
+    });
+    return () => {
+      active = false;
+      events?.close();
+    };
   }, [apply]);
+
+  useEffect(() => {
+    if (!state?.recoveryKey || !browserRecoveryReady.current) return;
+    if (!state.dirty && source === state.source) {
+      void clearBrowserRecovery(state.recoveryKey).catch(() => undefined);
+      return;
+    }
+    void writeBrowserRecovery(state.recoveryKey, {
+      kind: "markdown",
+      source,
+      diskVersion: draftBaseDiskVersion.current || diskVersion.current,
+      writtenAt: new Date().toISOString()
+    }).catch(() => {
+      if (!browserRecoveryWarningShown.current) {
+        browserRecoveryWarningShown.current = true;
+        toast.warning("Instant browser crash recovery is unavailable. Drafts are still protected after they reach the local Studio server.");
+      }
+    });
+  }, [source, state?.dirty, state?.source, state?.recoveryKey]);
+
+  useEffect(() => {
+    let active = true;
+    const renew = async () => {
+      try {
+        const { response } = await request("/__scribe/api/lease", { method: "POST", body: "{}" });
+        if (active) setWriter(response.ok);
+      } catch {
+        if (active) setWriter(false);
+      }
+    };
+    void renew();
+    const interval = setInterval(renew, 3_000);
+    const release = () => {
+      void fetch("/__scribe/api/lease/release", {
+        method: "POST",
+        keepalive: true,
+        headers: {
+          "content-type": "application/json",
+          "x-scribe-studio-session": studioSessionToken
+        },
+        body: JSON.stringify({ clientId: studioClientId })
+      });
+    };
+    addEventListener("pagehide", release);
+    return () => {
+      active = false;
+      clearInterval(interval);
+      removeEventListener("pagehide", release);
+      release();
+    };
+  }, []);
 
   useEffect(() => {
     if (authorMode !== "markdown" || !state || source === state.source) return;
     clearTimeout(updateTimer.current);
     updateTimer.current = setTimeout(async () => {
-      const { body } = await request("/__scribe/api/draft", { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ source }) });
-      apply(body);
+      const { response, body } = await request("/__scribe/api/draft", {
+        method: "PUT",
+        body: JSON.stringify({
+          source,
+          externalConflict: browserRecoveryConflict.current,
+          baseDiskVersion: draftBaseDiskVersion.current
+        })
+      });
+      if (response.ok) browserRecoveryConflict.current = false;
+      if (typeof body.source === "string") apply(body);
+      if (!response.ok) toast.error(body.error || "Studio could not preserve this draft.");
     }, 280);
     return () => clearTimeout(updateTimer.current);
   }, [source, state, apply, authorMode]);
@@ -422,12 +723,28 @@ function StudioApp() {
   const flushMarkdown = useCallback(async () => {
     clearTimeout(updateTimer.current);
     if (!state || source === state.source) return state;
-    const { body } = await request("/__scribe/api/draft", { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ source }) });
+    const { response, body } = await request("/__scribe/api/draft", {
+      method: "PUT",
+      body: JSON.stringify({
+        source,
+        externalConflict: browserRecoveryConflict.current,
+        baseDiskVersion: draftBaseDiskVersion.current
+      })
+    });
+    if (response.ok) browserRecoveryConflict.current = false;
+    if (!response.ok || typeof body.source !== "string") {
+      toast.error(body.error || "Studio could not preserve this draft.");
+      return state;
+    }
     apply(body, true);
     return body;
   }, [state, source, apply]);
 
   const enterRich = useCallback(async () => {
+    if (!writer) {
+      toast.error("Another Studio tab currently owns this draft.");
+      return;
+    }
     const current = await flushMarkdown();
     if (!current || current.diagnostics.some((item) => item.severity === "error")) {
       toast.error("Fix Markdown diagnostics before entering Rich Text mode.");
@@ -439,10 +756,15 @@ function StudioApp() {
       toast.error(body.error || "This document cannot enter Rich Text mode safely.");
       return;
     }
-    setRichSession({ ...body, tab: "markdown" });
+    setRichSession({
+      ...body,
+      tab: "markdown",
+      baseSource: current.source,
+      baseDiskVersion: draftBaseDiskVersion.current || current.diskVersion
+    });
     setRichError("");
     setAuthorModeState("rich");
-  }, [flushMarkdown]);
+  }, [flushMarkdown, writer]);
 
   const switchAuthorMode = useCallback(async (mode) => {
     if (mode === authorMode) return;
@@ -460,8 +782,32 @@ function StudioApp() {
 
   const hasUnwrittenChanges = Boolean(state && (state.dirty || source !== state.source || richPending));
 
+  const setRichPendingState = useCallback((pending) => {
+    richPendingRef.current = pending;
+    setRichPending(pending);
+  }, []);
+
+  const preserveRichCandidate = useCallback((candidate, session) => {
+    if (!state?.recoveryKey) return;
+    void writeBrowserRecovery(state.recoveryKey, {
+      kind: "rich",
+      candidate,
+      baseSource: session.baseSource,
+      diskVersion: session.baseDiskVersion,
+      writtenAt: new Date().toISOString()
+    }).catch(() => {
+      if (!browserRecoveryWarningShown.current) {
+        browserRecoveryWarningShown.current = true;
+        toast.warning("Instant browser crash recovery is unavailable. Drafts are still protected after they reach the local Studio server.");
+      }
+    });
+  }, [state?.recoveryKey]);
+
   const save = useCallback(async () => {
-    if (!state) return;
+    if (!state || !writer) {
+      toast.error("This tab is read-only while another Studio tab owns the draft.");
+      return;
+    }
     if (authorMode === "rich" && richFlushRef.current) {
       const accepted = await richFlushRef.current();
       if (!accepted) return;
@@ -469,12 +815,13 @@ function StudioApp() {
     const saved = await request("/__scribe/api/save", { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ expectedDiskVersion: diskVersion.current }) });
     if (saved.response.ok) {
       apply(saved.body, true);
+      void clearBrowserRecovery(saved.body.recoveryKey).catch(() => undefined);
       toast.success("Saved to " + saved.body.sourcePath);
     } else {
       if (typeof saved.body.source === "string") apply(saved.body, true);
       toast.error(saved.body.error || "Could not save the article");
     }
-  }, [state, authorMode, flushMarkdown, apply]);
+  }, [state, authorMode, flushMarkdown, apply, writer]);
 
   useEffect(() => {
     const onKeyDown = (event) => {
@@ -504,22 +851,31 @@ function StudioApp() {
     try { await navigator.clipboard.writeText(diagnostics); setCopyStatus("Diagnostics copied"); toast.success("Diagnostics copied"); }
     catch { setCopyStatus("Could not copy diagnostics"); toast.error("Clipboard access is unavailable"); }
   };
+  const recoverDiscard = async () => {
+    const { response, body } = await request("/__scribe/api/recover-discard", { method: "POST", body: "{}" });
+    if (!response.ok) return toast.error(body.error || "The discarded draft could not be recovered.");
+    apply(body, true);
+    void clearBrowserRecovery(body.recoveryKey).catch(() => undefined);
+    toast.success("Recovered the discarded draft");
+  };
   const discard = async () => {
-    const { body } = await request("/__scribe/api/discard", { method: "POST" });
+    const { body } = await request("/__scribe/api/discard", { method: "POST", body: "{}" });
     apply(body, true);
     setAuthorModeState("markdown");
     setRichSession(null);
     setRichError("");
-    toast("Reloaded the source from disk");
+    toast("Reloaded the source from disk", body.discardRecoveryAvailable
+      ? { action: { label: "Undo", onClick: recoverDiscard } }
+      : undefined);
   };
 
   return <Tooltip.Provider delay={350}><main className="studio-shell">
     <header className="studio-toolbar">
       <div className="studio-brand"><span className="studio-mark" aria-hidden="true"><TerminalSquare /></span><div><strong>Scribe Studio</strong><span>Markdown source · visual helper · production renderer</span></div></div>
-      <Status state={state} richError={richError} />
+      <Status state={state} richError={richError} writer={writer} connected={connected} />
       <div className="studio-actions">
         {(state.diagnostics.length > 0 || richError) && <Hint label="Copy diagnostics"><Button id="copy-diagnostics" type="button" size="icon" variant="ghost" aria-label="Copy diagnostics" onClick={copyDiagnostics}><ClipboardCopy aria-hidden="true" /></Button></Hint>}
-        <Button id="save" type="button" variant="default" onClick={save}><Save data-icon="inline-start" aria-hidden="true" />Save <kbd>⌘S</kbd></Button>
+        <Button id="save" type="button" variant="default" onClick={save} disabled={!writer}><Save data-icon="inline-start" aria-hidden="true" />Save <kbd>⌘S</kbd></Button>
       </div>
     </header>
 
@@ -533,7 +889,7 @@ function StudioApp() {
       <span className="document-meta">{lines} lines <i /> {words} words</span>
     </div>
 
-    <Workspace authorMode={authorMode} state={state} source={source} setSource={setSource} textareaRef={textareaRef} theme={theme} viewport={viewport} richSession={richSession} setRichSession={setRichSession} richError={richError} setRichError={setRichError} setAuthorMode={applyRichState} setRichPending={setRichPending} registerRichFlush={(flush) => { richFlushRef.current = flush; }} revealProtected={revealProtected} />
+    <Workspace authorMode={authorMode} state={state} source={source} setSource={updateSource} textareaRef={textareaRef} theme={theme} viewport={viewport} richSession={richSession} setRichSession={setRichSession} richError={richError} setRichError={setRichError} setAuthorMode={applyRichState} setRichPending={setRichPendingState} preserveRichCandidate={preserveRichCandidate} registerRichFlush={(flush) => { richFlushRef.current = flush; }} revealProtected={revealProtected} writer={writer} />
 
     {richError && <div className="rich-error" role="alert"><TriangleAlert aria-hidden="true" /><div><strong>Rich Text edit rejected</strong><span>{richError}</span><small>The Markdown draft was not changed.</small></div><Button type="button" size="sm" onClick={() => switchAuthorMode("markdown")}><FileText data-icon="inline-start" aria-hidden="true" />Edit in Markdown</Button></div>}
     {state.conflict && <div className="conflict-card" role="alert"><TriangleAlert aria-hidden="true" /><div><strong>Source changed outside Studio</strong><span>Your unsaved draft and the disk version are both preserved.</span></div><Button type="button" size="sm" onClick={discard}><RotateCcw data-icon="inline-start" aria-hidden="true" />Reload from disk</Button></div>}

--- a/packages/cli/src/studio.test.ts
+++ b/packages/cli/src/studio.test.ts
@@ -5,6 +5,7 @@ import { createServer as createNetServer } from "node:net";
 
 import { afterEach, expect, it, vi } from "vitest";
 
+import { studioRecoveryKey } from "./studio-recovery.js";
 import { formatStudioStartup, parseStudioArguments, runStudio, startStudio, type StudioHandle } from "./studio.js";
 
 const handles: StudioHandle[] = [];
@@ -70,6 +71,21 @@ it("formats Studio startup with a project-relative source path", () => {
 
   expect(output).toMatch(/Source  content[\\/]peer notes\.mdx/u);
   expect(output).not.toContain(root);
+});
+
+it("surfaces recovery read failures before opening the Studio", async () => {
+  const file = await fixture();
+  const recoveryRoot = await mkdtemp(join(tmpdir(), "scribe recovery failure "));
+  await mkdir(join(recoveryRoot, "recovery", `${studioRecoveryKey(file.path)}.json`), { recursive: true });
+
+  await expect(startStudio({
+    root: file.root,
+    path: file.path,
+    mode: "default",
+    port: 0,
+    open: false,
+    recoveryRoot
+  })).rejects.toThrow("Studio could not read its local recovery state");
 });
 
 it("requires an explicit Studio mode when project detection is ambiguous", async () => {
@@ -144,6 +160,21 @@ it("rejects cross-origin mutations and prevents a second tab from taking the wri
     body: "{}"
   });
   expect(unauthenticated.status).toBe(403);
+
+  const authenticatedCrossSite = await fetch(`${handle.origin}/__scribe/api/discard`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-scribe-studio-session": handle.sessionToken,
+      origin: "https://attacker.invalid",
+      "sec-fetch-site": "cross-site"
+    },
+    body: "{}"
+  });
+  expect(authenticatedCrossSite.status).toBe(403);
+  await expect(authenticatedCrossSite.json()).resolves.toMatchObject({
+    error: expect.stringContaining("Cross-site")
+  });
 
   const first = await mutate(handle, "/__scribe/api/draft", { source: "# First tab\n" });
   expect(first.status).toBe(200);

--- a/packages/cli/src/studio.test.ts
+++ b/packages/cli/src/studio.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, unlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, symlink, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer as createNetServer } from "node:net";
@@ -8,6 +8,8 @@ import { afterEach, expect, it, vi } from "vitest";
 import { formatStudioStartup, parseStudioArguments, runStudio, startStudio, type StudioHandle } from "./studio.js";
 
 const handles: StudioHandle[] = [];
+let operation = 0;
+process.env["SCRIBE_STUDIO_STATE_DIR"] = join(tmpdir(), `scribe-studio-vitest-${process.pid}`);
 afterEach(async () => Promise.all(handles.splice(0).map((handle) => handle.close())));
 
 async function fixture(name = "article.mdx", source = "# Peer states\n"): Promise<{ root: string; path: string }> {
@@ -17,6 +19,29 @@ async function fixture(name = "article.mdx", source = "# Peer states\n"): Promis
   await writeFile(path, source);
   await writeFile(join(root, "package.json"), JSON.stringify({ dependencies: { react: "19.2.7", vite: "8.1.3" } }));
   return { root, path };
+}
+
+async function mutate(
+  handle: StudioHandle,
+  path: string,
+  body: Record<string, unknown> = {},
+  baseRevision?: number
+): Promise<Response> {
+  const revision = baseRevision ?? ((await (await fetch(`${handle.origin}/__scribe/api/document`)).json()) as { revision: number }).revision;
+  return fetch(`${handle.origin}${path}`, {
+    method: path.endsWith("discard") ? "POST" : "PUT",
+    headers: {
+      "content-type": "application/json",
+      "x-scribe-studio-session": handle.sessionToken,
+      origin: handle.origin
+    },
+    body: JSON.stringify({
+      ...body,
+      clientId: "vitest",
+      operationId: `vitest-${++operation}`,
+      baseRevision: revision
+    })
+  });
 }
 
 it("parses the documented studio command surface and rejects unknown flags", () => {
@@ -62,6 +87,7 @@ it("starts on loopback, loads the source, and reports metadata", async () => {
   const file = await fixture("peer notes.mdx", "---\ntitle: Peer notes\n---\n# Peer states\n");
   await mkdir(join(file.root, "public"), { recursive: true });
   await writeFile(join(file.root, "public", "peer-banner.svg"), '<svg xmlns="http://www.w3.org/2000/svg"/>');
+  await symlink(file.path, join(file.root, "public", "escaped.svg"));
   const handle = await startStudio({ root: file.root, path: file.path, mode: "foundation", port: 0, open: false });
   handles.push(handle);
 
@@ -82,20 +108,6 @@ it("starts on loopback, loads the source, and reports metadata", async () => {
   expect(studio).toContain('src="/@scribe-studio/client.tsx"');
   expect(studio).not.toContain('id="mode"');
 
-  const client = await (await fetch(`${handle.origin}/@scribe-studio/client.tsx`)).text();
-  expect(client).toContain("MDXEditor");
-  expect(client).toContain("lucide-react");
-  expect(client).toContain("Scribe Studio");
-  expect(client).toContain("Rich Text");
-  expect(client).toContain("format_align_left: AlignLeft");
-  expect(client).toContain("format_align_center: AlignCenter");
-  expect(client).toContain("format_align_right: AlignRight");
-  expect(client).not.toContain('aria-label="Markdown formatting"');
-
-  const styles = await (await fetch(`${handle.origin}/@scribe-studio/styles.css`)).text();
-  expect(styles).toContain("#CDFF57");
-  expect(styles).toContain("#0A0A0A");
-
   const publicImage = await fetch(`${handle.origin}/peer-banner.svg`);
   expect(publicImage.status).toBe(200);
 
@@ -106,6 +118,8 @@ it("starts on loopback, loads the source, and reports metadata", async () => {
   const missingAsset = await fetch(`${handle.origin}/__scribe/api/asset?path=${encodeURIComponent("/missing.webp")}`);
   expect(missingAsset.status).toBe(200);
   await expect(missingAsset.json()).resolves.toEqual({ exists: false });
+  const escapedAsset = await fetch(`${handle.origin}/__scribe/api/asset?path=${encodeURIComponent("/escaped.svg")}`);
+  await expect(escapedAsset.json()).resolves.toEqual({ exists: false });
 });
 
 it("keeps the detected style mode locked while drafts change", async () => {
@@ -113,14 +127,46 @@ it("keeps the detected style mode locked while drafts change", async () => {
   const handle = await startStudio({ root: file.root, path: file.path, mode: "default", port: 0, open: false });
   handles.push(handle);
 
-  const response = await fetch(`${handle.origin}/__scribe/api/draft`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ source: "# Updated without a mode field\n" })
-  });
+  const response = await mutate(handle, "/__scribe/api/draft", { source: "# Updated without a mode field\n" });
 
   expect(response.status).toBe(200);
   await expect(response.json()).resolves.toMatchObject({ ok: true, mode: "default" });
+});
+
+it("rejects cross-origin mutations and prevents a second tab from taking the writer lease", async () => {
+  const file = await fixture();
+  const handle = await startStudio({ root: file.root, path: file.path, mode: "default", port: 0, open: false });
+  handles.push(handle);
+
+  const unauthenticated = await fetch(`${handle.origin}/__scribe/api/discard`, {
+    method: "POST",
+    headers: { "content-type": "application/json", origin: "https://attacker.invalid" },
+    body: "{}"
+  });
+  expect(unauthenticated.status).toBe(403);
+
+  const first = await mutate(handle, "/__scribe/api/draft", { source: "# First tab\n" });
+  expect(first.status).toBe(200);
+  const current = await (await fetch(`${handle.origin}/__scribe/api/document`)).json() as { revision: number };
+  const second = await fetch(`${handle.origin}/__scribe/api/draft`, {
+    method: "PUT",
+    headers: {
+      "content-type": "application/json",
+      "x-scribe-studio-session": handle.sessionToken,
+      origin: handle.origin
+    },
+    body: JSON.stringify({
+      source: "# Second tab\n",
+      clientId: "second-tab",
+      operationId: "second-tab-1",
+      baseRevision: current.revision
+    })
+  });
+  expect(second.status).toBe(423);
+  await expect(second.json()).resolves.toMatchObject({ code: "SCB_STUDIO_WRITER_LOCKED" });
+  await expect((await fetch(`${handle.origin}/__scribe/api/document`)).json()).resolves.toMatchObject({
+    source: "# First tab\n"
+  });
 });
 
 it("projects protected MDX for Rich Text mode and accepts only preservation-safe edits", async () => {
@@ -143,14 +189,9 @@ it("projects protected MDX for Rich Text mode and accepts only preservation-safe
     '<Callout variant="note">Keep this exact.</Callout>'
   ]);
 
-  const safe = await fetch(`${handle.origin}/__scribe/api/rich-draft`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      source: projected.projectionMarkdown.replace("Original paragraph.", "Edited paragraph."),
-      revision: projected.revision
-    })
-  });
+  const safe = await mutate(handle, "/__scribe/api/rich-draft", {
+    source: projected.projectionMarkdown.replace("Original paragraph.", "Edited paragraph.")
+  }, projected.revision);
   expect(safe.status).toBe(200);
   await expect(safe.json()).resolves.toMatchObject({ ok: true, source: expect.stringContaining("Edited paragraph.") });
 
@@ -158,14 +199,9 @@ it("projects protected MDX for Rich Text mode and accepts only preservation-safe
     projectionMarkdown: string;
     revision: number;
   };
-  const unsafe = await fetch(`${handle.origin}/__scribe/api/rich-draft`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      source: afterSafe.projectionMarkdown.replace(/<ScribeStudioProtectedIsland[^>]+\/>/u, ""),
-      revision: afterSafe.revision
-    })
-  });
+  const unsafe = await mutate(handle, "/__scribe/api/rich-draft", {
+    source: afterSafe.projectionMarkdown.replace(/<ScribeStudioProtectedIsland[^>]+\/>/u, "")
+  }, afterSafe.revision);
   expect(unsafe.status).toBe(422);
   await expect(unsafe.json()).resolves.toMatchObject({
     ok: false,
@@ -185,17 +221,11 @@ it("invalidates a stale Rich Text projection without overwriting the current dra
     projectionMarkdown: string;
     revision: number;
   };
-  await fetch(`${handle.origin}/__scribe/api/draft`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ source: "# Markdown edit\n" })
-  });
+  await mutate(handle, "/__scribe/api/draft", { source: "# Markdown edit\n" });
 
-  const stale = await fetch(`${handle.origin}/__scribe/api/rich-draft`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ source: projected.projectionMarkdown, revision: projected.revision })
-  });
+  const stale = await mutate(handle, "/__scribe/api/rich-draft", {
+    source: projected.projectionMarkdown
+  }, projected.revision);
   expect(stale.status).toBe(409);
   await expect(stale.json()).resolves.toMatchObject({
     ok: false,
@@ -209,10 +239,9 @@ it("keeps invalid drafts editable, recovers the preview, and saves atomically", 
   const handle = await startStudio({ root: file.root, path: file.path, mode: "default", port: 0, open: false });
   handles.push(handle);
 
-  const invalid = await fetch(`${handle.origin}/__scribe/api/draft`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ source: "<Callout>unfinished", mode: "default" })
+  const invalid = await mutate(handle, "/__scribe/api/draft", {
+    source: "<Callout>unfinished",
+    mode: "default"
   });
   expect(invalid.status).toBe(200);
   expect(await invalid.json()).toMatchObject({ ok: false, diagnostics: [expect.objectContaining({ line: 1 })] });
@@ -225,21 +254,56 @@ it("keeps invalid drafts editable, recovers the preview, and saves atomically", 
   });
 
   const validSource = "# Recovered\n\n| State | Meaning |\n| --- | --- |\n| ready | valid |\n";
-  const valid = await fetch(`${handle.origin}/__scribe/api/draft`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ source: validSource, mode: "foundation" })
+  const valid = await mutate(handle, "/__scribe/api/draft", {
+    source: validSource,
+    mode: "foundation"
   });
   expect(valid.status).toBe(200);
   const state = await valid.json() as { diskVersion: string };
 
-  const saved = await fetch(`${handle.origin}/__scribe/api/save`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ expectedDiskVersion: state.diskVersion })
-  });
+  const saved = await mutate(handle, "/__scribe/api/save", { expectedDiskVersion: state.diskVersion });
   expect(saved.status).toBe(200);
   expect(await readFile(file.path, "utf8")).toBe(validSource);
+});
+
+it("recovers an acknowledged draft after Studio restarts without touching the article", async () => {
+  const file = await fixture("recovery.mdx", "# On disk\n");
+  const first = await startStudio({ root: file.root, path: file.path, mode: "default", port: 0, open: false });
+  const updated = await mutate(first, "/__scribe/api/draft", { source: "# Recovered draft\n" });
+  expect(updated.status).toBe(200);
+  await first.close();
+  expect(await readFile(file.path, "utf8")).toBe("# On disk\n");
+
+  const restarted = await startStudio({ root: file.root, path: file.path, mode: "default", port: 0, open: false });
+  handles.push(restarted);
+  await expect((await fetch(`${restarted.origin}/__scribe/api/document`)).json()).resolves.toMatchObject({
+    source: "# Recovered draft\n",
+    dirty: true,
+    recovered: true,
+    conflict: false
+  });
+});
+
+it("keeps a discarded draft recoverable until the user explicitly resumes it", async () => {
+  const file = await fixture("discard-recovery.mdx", "# On disk\n");
+  const handle = await startStudio({ root: file.root, path: file.path, mode: "default", port: 0, open: false });
+  handles.push(handle);
+  await mutate(handle, "/__scribe/api/draft", { source: "# Unsaved\n" });
+
+  const discarded = await mutate(handle, "/__scribe/api/discard");
+  await expect(discarded.json()).resolves.toMatchObject({
+    source: "# On disk\n",
+    discardRecoveryAvailable: true
+  });
+  const recovered = await mutate(handle, "/__scribe/api/recover-discard");
+  const recoveredBody = await recovered.json();
+  expect({ status: recovered.status, body: recoveredBody }).toMatchObject({ status: 200 });
+  expect(recoveredBody).toMatchObject({
+    source: "# Unsaved\n",
+    dirty: true,
+    recovered: true
+  });
+  expect(await readFile(file.path, "utf8")).toBe("# On disk\n");
 });
 
 it("detects external changes and refuses to overwrite an unsaved draft", async () => {
@@ -248,10 +312,9 @@ it("detects external changes and refuses to overwrite an unsaved draft", async (
   handles.push(handle);
   const initial = await (await fetch(`${handle.origin}/__scribe/api/document`)).json() as { diskVersion: string };
 
-  await fetch(`${handle.origin}/__scribe/api/draft`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ source: "# Unsaved studio draft\n", mode: "default" })
+  await mutate(handle, "/__scribe/api/draft", {
+    source: "# Unsaved studio draft\n",
+    mode: "default"
   });
   await writeFile(file.path, "# External editor change\n");
 
@@ -260,15 +323,11 @@ it("detects external changes and refuses to overwrite an unsaved draft", async (
     return state.conflict;
   }).toBe(true);
 
-  const saved = await fetch(`${handle.origin}/__scribe/api/save`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ expectedDiskVersion: initial.diskVersion })
-  });
+  const saved = await mutate(handle, "/__scribe/api/save", { expectedDiskVersion: initial.diskVersion });
   expect(saved.status).toBe(409);
   expect(await readFile(file.path, "utf8")).toBe("# External editor change\n");
 
-  const reloaded = await fetch(`${handle.origin}/__scribe/api/discard`, { method: "POST" });
+  const reloaded = await mutate(handle, "/__scribe/api/discard");
   expect(reloaded.status).toBe(200);
   await expect(reloaded.json()).resolves.toMatchObject({
     source: "# External editor change\n",
@@ -277,24 +336,87 @@ it("detects external changes and refuses to overwrite an unsaved draft", async (
   });
 });
 
+it("journals a browser draft against its original disk version when an external edit wins the debounce race", async () => {
+  const file = await fixture("debounce-conflict.mdx", "# Original\n");
+  const first = await startStudio({ root: file.root, path: file.path, mode: "default", port: 0, open: false });
+  const initial = await (await fetch(`${first.origin}/__scribe/api/document`)).json() as {
+    diskVersion: string;
+  };
+
+  await writeFile(file.path, "# External\n");
+  await expect.poll(async () => {
+    const current = await (await fetch(`${first.origin}/__scribe/api/document`)).json() as { diskVersion: string };
+    return current.diskVersion;
+  }).not.toBe(initial.diskVersion);
+
+  const preserved = await mutate(first, "/__scribe/api/draft", {
+    source: "# Local browser typing\n",
+    externalConflict: true,
+    baseDiskVersion: initial.diskVersion
+  });
+  await expect(preserved.json()).resolves.toMatchObject({
+    source: "# Local browser typing\n",
+    dirty: true,
+    conflict: true,
+    recoveryConflict: true
+  });
+  await first.close();
+
+  const restarted = await startStudio({ root: file.root, path: file.path, mode: "default", port: 0, open: false });
+  handles.push(restarted);
+  await expect((await fetch(`${restarted.origin}/__scribe/api/document`)).json()).resolves.toMatchObject({
+    source: "# Local browser typing\n",
+    dirty: true,
+    conflict: true,
+    recovered: true,
+    recoveryConflict: true
+  });
+  expect(await readFile(file.path, "utf8")).toBe("# External\n");
+});
+
+it("preserves a pending Rich Text candidate when the source changes externally", async () => {
+  const file = await fixture("rich-conflict.mdx", "# Original\n\nA paragraph.\n");
+  const handle = await startStudio({ root: file.root, path: file.path, mode: "default", port: 0, open: false });
+  handles.push(handle);
+  const initial = await (await fetch(`${handle.origin}/__scribe/api/document`)).json() as {
+    diskVersion: string;
+  };
+  const projected = await (await fetch(`${handle.origin}/__scribe/api/rich-projection`)).json() as {
+    projectionMarkdown: string;
+  };
+
+  await writeFile(file.path, "# External\n\nChanged in the IDE.\n");
+  await expect.poll(async () => {
+    const current = await (await fetch(`${handle.origin}/__scribe/api/document`)).json() as { diskVersion: string };
+    return current.diskVersion;
+  }).not.toBe(initial.diskVersion);
+
+  const preserved = await mutate(handle, "/__scribe/api/rich-draft", {
+    source: projected.projectionMarkdown.replace("A paragraph.", "Typing from Rich Text."),
+    baseSource: "# Original\n\nA paragraph.\n",
+    baseDiskVersion: initial.diskVersion
+  });
+
+  expect(preserved.status).toBe(200);
+  await expect(preserved.json()).resolves.toMatchObject({
+    source: expect.stringContaining("Typing from Rich Text."),
+    dirty: true,
+    conflict: true,
+    recoveryConflict: true
+  });
+  expect(await readFile(file.path, "utf8")).toBe("# External\n\nChanged in the IDE.\n");
+});
+
 it("revalidates the source on disk immediately before saving", async () => {
   const file = await fixture();
   const handle = await startStudio({ root: file.root, path: file.path, mode: "default", port: 0, open: false });
   handles.push(handle);
   const initial = await (await fetch(`${handle.origin}/__scribe/api/document`)).json() as { diskVersion: string };
 
-  await fetch(`${handle.origin}/__scribe/api/draft`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ source: "# Unsaved studio draft\n" })
-  });
+  await mutate(handle, "/__scribe/api/draft", { source: "# Unsaved studio draft\n" });
   await writeFile(file.path, "# External editor change before watcher delivery\n");
 
-  const saved = await fetch(`${handle.origin}/__scribe/api/save`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ expectedDiskVersion: initial.diskVersion })
-  });
+  const saved = await mutate(handle, "/__scribe/api/save", { expectedDiskVersion: initial.diskVersion });
 
   expect(saved.status).toBe(409);
   await expect(saved.json()).resolves.toMatchObject({
@@ -304,23 +426,46 @@ it("revalidates the source on disk immediately before saving", async () => {
   expect(await readFile(file.path, "utf8")).toBe("# External editor change before watcher delivery\n");
 });
 
+it("refuses to save through a source symlink whose target changed after startup", async () => {
+  const root = await mkdtemp(join(tmpdir(), "scribe studio symlink swap "));
+  const firstTarget = join(root, "first.mdx");
+  const secondTarget = join(root, "second.mdx");
+  const sourceLink = join(root, "article.mdx");
+  await writeFile(firstTarget, "# Same bytes\n");
+  await writeFile(secondTarget, "# Same bytes\n");
+  await symlink(firstTarget, sourceLink);
+  await writeFile(join(root, "package.json"), JSON.stringify({ dependencies: { react: "19.2.7", vite: "8.1.3" } }));
+  const handle = await startStudio({ root, path: sourceLink, mode: "default", port: 0, open: false });
+  handles.push(handle);
+  const initial = await (await fetch(`${handle.origin}/__scribe/api/document`)).json() as { diskVersion: string };
+
+  await mutate(handle, "/__scribe/api/draft", { source: "# Unsaved Studio draft\n" });
+  await unlink(sourceLink);
+  await symlink(secondTarget, sourceLink);
+  const saved = await mutate(handle, "/__scribe/api/save", { expectedDiskVersion: initial.diskVersion });
+
+  expect(saved.status).toBe(409);
+  await expect(saved.json()).resolves.toMatchObject({
+    conflict: true,
+    source: "# Unsaved Studio draft\n",
+    error: expect.stringContaining("target changed")
+  });
+  expect(await readFile(secondTarget, "utf8")).toBe("# Same bytes\n");
+});
+
 it("keeps the draft conflicted when reload cannot read a deleted source", async () => {
   const file = await fixture();
   const handle = await startStudio({ root: file.root, path: file.path, mode: "default", port: 0, open: false });
   handles.push(handle);
 
-  await fetch(`${handle.origin}/__scribe/api/draft`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ source: "# Unsaved studio draft\n" })
-  });
+  await mutate(handle, "/__scribe/api/draft", { source: "# Unsaved studio draft\n" });
   await unlink(file.path);
   await expect.poll(async () => {
     const state = await (await fetch(`${handle.origin}/__scribe/api/document`)).json() as { conflict: boolean };
     return state.conflict;
   }).toBe(true);
 
-  const reloaded = await fetch(`${handle.origin}/__scribe/api/discard`, { method: "POST" });
+  const reloaded = await mutate(handle, "/__scribe/api/discard");
 
   expect(reloaded.status).toBe(409);
   await expect(reloaded.json()).resolves.toMatchObject({
@@ -337,16 +482,8 @@ it("preserves CRLF line endings when a draft is saved", async () => {
   handles.push(handle);
   const initial = await (await fetch(`${handle.origin}/__scribe/api/document`)).json() as { diskVersion: string };
 
-  await fetch(`${handle.origin}/__scribe/api/draft`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ source: "# Peer states\n\nUpdated.\n" })
-  });
-  const saved = await fetch(`${handle.origin}/__scribe/api/save`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ expectedDiskVersion: initial.diskVersion })
-  });
+  await mutate(handle, "/__scribe/api/draft", { source: "# Peer states\n\nUpdated.\n" });
+  const saved = await mutate(handle, "/__scribe/api/save", { expectedDiskVersion: initial.diskVersion });
 
   expect(saved.status).toBe(200);
   expect(await readFile(file.path, "utf8")).toBe("# Peer states\r\n\r\nUpdated.\r\n");
@@ -355,9 +492,15 @@ it("preserves CRLF line endings when a draft is saved", async () => {
 it("rejects source and host CSS paths outside the selected workspace", async () => {
   const inside = await fixture();
   const outside = await fixture("outside.mdx");
+  const linkedSource = join(inside.root, "content", "linked.mdx");
+  const linkedCss = join(inside.root, "linked.css");
+  await symlink(outside.path, linkedSource);
+  await symlink(outside.path, linkedCss);
 
   await expect(startStudio({ root: inside.root, path: outside.path, mode: "default", port: 0, open: false })).rejects.toThrow("outside the Studio workspace");
   await expect(startStudio({ root: inside.root, path: inside.path, hostCss: outside.path, mode: "default", port: 0, open: false })).rejects.toThrow("outside the Studio workspace");
+  await expect(startStudio({ root: inside.root, path: linkedSource, mode: "default", port: 0, open: false })).rejects.toThrow("Resolved source file is outside");
+  await expect(startStudio({ root: inside.root, path: inside.path, hostCss: linkedCss, mode: "default", port: 0, open: false })).rejects.toThrow("Resolved host CSS is outside");
 });
 
 it("fails clearly for missing files and occupied ports", async () => {

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -1,20 +1,46 @@
-import { createHash } from "node:crypto";
 import { spawn } from "node:child_process";
 import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
 import { createRequire } from "node:module";
 import { constants } from "node:fs";
-import { access, mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import { access, realpath, stat } from "node:fs/promises";
 import { dirname, extname, isAbsolute, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import mdx from "@mdx-js/rollup";
-import { compileScribeMdx, createScribeMdxOptions } from "@scribe-sdk/mdx";
+import { createScribeMdxOptions } from "@scribe-sdk/mdx";
 import react from "@vitejs/plugin-react";
-import { createServer as createViteServer, normalizePath, type Plugin, type ViteDevServer } from "vite";
+import {
+  createServer as createViteServer,
+  normalizePath,
+  transformWithOxc,
+  type Plugin,
+  type ViteDevServer
+} from "vite";
 
 import { displayPath, suggestClosest } from "./cli-output.js";
 import { resolveProjectStyleMode, type StyleMode } from "./init.js";
-import { acceptRichCandidate, createRichProjection, type RichProjection } from "./rich-preservation.js";
+import {
+  durableWriteStudioFile,
+  readStudioFile,
+  StudioFileConflictError,
+  type StudioFileSnapshot
+} from "./studio-files.js";
+import { StudioCompiler, type StudioCompilerDiagnostic } from "./studio-compiler.js";
+import { StudioEventHub } from "./studio-events.js";
+import {
+  acceptRichCandidate,
+  createRichProjection,
+  type RichCandidateResult,
+  type RichProjection
+} from "./rich-preservation.js";
+import { StudioWriterLease } from "./studio-lease.js";
+import { StudioRecoveryStore, studioRecoveryKey } from "./studio-recovery.js";
+import { authorizeStudioMutation, createStudioSession, studioSessionHeader, type StudioSession } from "./studio-security.js";
+import {
+  StudioTransactionCoordinator,
+  type StudioMutationRequest,
+  type StudioMutationResult
+} from "./studio-transactions.js";
 import { studioClientModule, studioStyles, type StudioClientImports } from "./studio-ui.js";
 
 const studioRequire = createRequire(import.meta.url);
@@ -27,10 +53,15 @@ export interface StudioOptions {
   readonly hostCss?: string;
   readonly port: number;
   readonly open: boolean;
+  /** Override used by isolated tests; normal sessions use the OS state directory. */
+  readonly recoveryRoot?: string;
 }
 
 export interface StudioHandle {
   readonly origin: string;
+  /** Internal capability used by Studio's own client and focused integration tests. */
+  readonly sessionToken: string;
+  readonly hasUnsavedChanges: () => boolean;
   readonly close: () => Promise<void>;
 }
 
@@ -62,14 +93,24 @@ interface StudioState {
   diagnostics: StudioDiagnostic[];
   revision: number;
   richProjection: RichProjection | undefined;
+  fileSnapshot: StudioFileSnapshot;
+  recoveryBaseVersion: string;
+  recovered: boolean;
+  recoveryConflict: boolean;
+  discardRecoveryAvailable: boolean;
+  recoveryKey: string;
 }
 
-interface StudioDiagnostic {
-  readonly severity: "error" | "warning";
-  readonly code: string;
-  readonly message: string;
-  readonly line?: number;
-  readonly column?: number;
+type StudioDiagnostic = StudioCompilerDiagnostic;
+
+interface StudioMutationHttpResult {
+  readonly status: number;
+  readonly error?: string;
+}
+
+interface RichMutationValue {
+  readonly result: RichCandidateResult;
+  readonly projection: RichProjection;
 }
 
 const styleModes = new Set<StyleMode>(["foundation", "default", "tailwind"]);
@@ -136,38 +177,66 @@ export function parseStudioArguments(args: readonly string[]): StudioArguments |
 
 export async function startStudio(options: StudioOptions): Promise<StudioHandle> {
   const root = resolve(options.root);
-  const sourcePath = resolve(root, options.path);
-  assertWithinWorkspace(root, sourcePath, "Source file");
-  if (!articleExtensions.has(extname(sourcePath).toLowerCase())) throw new Error("Studio source must use a .md or .mdx extension.");
-  await access(sourcePath, constants.R_OK | constants.W_OK);
+  const resolvedRoot = await realpath(root);
+  const requestedSourcePath = resolve(root, options.path);
+  assertWithinWorkspace(root, requestedSourcePath, "Source file");
+  if (!articleExtensions.has(extname(requestedSourcePath).toLowerCase())) throw new Error("Studio source must use a .md or .mdx extension.");
+  await access(requestedSourcePath, constants.R_OK | constants.W_OK);
+  const fileSnapshot = await readStudioFile(requestedSourcePath);
+  assertWithinWorkspace(resolvedRoot, fileSnapshot.resolvedPath, "Resolved source file");
+  const sourcePath = fileSnapshot.resolvedPath;
 
   const hostCss = options.hostCss === undefined ? undefined : resolve(root, options.hostCss);
   if (hostCss !== undefined) {
     assertWithinWorkspace(root, hostCss, "Host CSS");
     if (extname(hostCss).toLowerCase() !== ".css") throw new Error("--host-css must reference a .css file.");
     await access(hostCss, constants.R_OK);
+    assertWithinWorkspace(resolvedRoot, await realpath(hostCss), "Resolved host CSS");
   }
 
-  const diskSource = await readUtf8(sourcePath);
+  const recovery = new StudioRecoveryStore(sourcePath, options.recoveryRoot);
+  const recoveredDraft = await recovery.loadDraft();
+  const runtime = studioRuntimePaths();
+  const compiler = new StudioCompiler();
+  const canRecover = recoveredDraft?.sourcePath === sourcePath && recoveredDraft.draftSource !== fileSnapshot.source;
+  const diskSource = fileSnapshot.source;
+  const draftSource = canRecover ? recoveredDraft.draftSource : diskSource;
+  let initialDiagnostics: StudioDiagnostic[];
+  try {
+    initialDiagnostics = await diagnosticsFor(compiler, sourcePath, draftSource);
+  } catch (error) {
+    await compiler.close();
+    throw error;
+  }
+  const recoveredPreview = initialDiagnostics.some(({ severity }) => severity === "error") ? diskSource : draftSource;
   const state: StudioState = {
-    sourcePath: normalizePath(relative(root, sourcePath)),
+    sourcePath: normalizePath(relative(root, requestedSourcePath)),
     diskSource,
-    draftSource: diskSource,
-    previewSource: diskSource,
-    diskVersion: fingerprint(diskSource),
+    draftSource,
+    previewSource: recoveredPreview,
+    diskVersion: fileSnapshot.version,
     previewVersion: 1,
     mode: options.mode,
     modeReason: options.modeReason ?? "Selected explicitly by the Studio caller.",
-    lineEnding: detectLineEnding(diskSource),
-    dirty: false,
-    conflict: false,
-    diagnostics: await diagnosticsFor(sourcePath, diskSource),
-    revision: 1,
-    richProjection: undefined
+    lineEnding: fileSnapshot.lineEnding,
+    dirty: draftSource !== diskSource,
+    conflict: Boolean(canRecover && recoveredDraft.baseDiskVersion !== fileSnapshot.version),
+    diagnostics: initialDiagnostics,
+    revision: canRecover ? Math.max(1, recoveredDraft.revision) : 1,
+    richProjection: undefined,
+    fileSnapshot,
+    recoveryBaseVersion: canRecover ? recoveredDraft.baseDiskVersion : fileSnapshot.version,
+    recovered: Boolean(canRecover),
+    recoveryConflict: Boolean(canRecover && recoveredDraft.baseDiskVersion !== fileSnapshot.version),
+    discardRecoveryAvailable: false,
+    recoveryKey: studioRecoveryKey(sourcePath)
   };
+  const coordinator = new StudioTransactionCoordinator(state.revision);
+  const session = createStudioSession();
+  const lease = new StudioWriterLease();
+  const events = new StudioEventHub();
 
   const articleId = `${sourcePath}.scribe-studio.mdx`;
-  const runtime = studioRuntimePaths();
   let server: ViteDevServer;
   const httpServer = createHttpServer((request, response) => {
     server.middlewares(request, response, (error: unknown) => {
@@ -176,8 +245,23 @@ export async function startStudio(options: StudioOptions): Promise<StudioHandle>
       response.end(error === undefined ? "Not found." : "Scribe Studio request failed.");
     });
   });
-  const studioPlugin = createStudioPlugin({ root, sourcePath, articleId, state, runtime, ...(hostCss === undefined ? {} : { hostCss }) });
-  server = await createViteServer({
+  const studioPlugin = createStudioPlugin({
+    root,
+    sourcePath,
+    requestedSourcePath,
+    articleId,
+    state,
+    runtime,
+    coordinator,
+    session,
+    lease,
+    recovery,
+    compiler,
+    events,
+    ...(hostCss === undefined ? {} : { hostCss })
+  });
+  try {
+    server = await createViteServer({
     configFile: false,
     root,
     appType: "custom",
@@ -187,7 +271,7 @@ export async function startStudio(options: StudioOptions): Promise<StudioHandle>
       port: options.port,
       strictPort: options.port !== 0,
       open: false,
-      hmr: false,
+      hmr: { server: httpServer },
       fs: { strict: true, allow: [root, ...Object.values(runtime).map(dirname)] }
     },
     resolve: {
@@ -195,6 +279,8 @@ export async function startStudio(options: StudioOptions): Promise<StudioHandle>
       dedupe: ["react", "react-dom"]
     },
     optimizeDeps: {
+      noDiscovery: true,
+      holdUntilCrawlEnd: false,
       include: [
         "react",
         "react-dom",
@@ -214,51 +300,105 @@ export async function startStudio(options: StudioOptions): Promise<StudioHandle>
         "tailwind-merge"
       ]
     },
-    plugins: [studioPlugin, { ...mdx(createScribeMdxOptions()), enforce: "pre" }, react()]
-  });
+      plugins: [studioPlugin, { ...mdx(createScribeMdxOptions()), enforce: "pre" }, react()]
+    });
+  } catch (error) {
+    await compiler.close();
+    throw error;
+  }
 
   try {
     await listenOnLoopback(httpServer, options.port);
   } catch (error) {
-    await server.close();
+    await Promise.all([server.close(), compiler.close()]);
     throw new Error(`Could not start Scribe Studio on 127.0.0.1:${options.port}: ${error instanceof Error ? error.message : String(error)}`);
   }
 
   server.watcher.add(sourcePath);
-  server.watcher.on("change", async (path) => {
+  const handleExternalChange = (path: string) => {
     if (resolve(path) !== sourcePath) return;
-    const source = await readUtf8(sourcePath);
-    if (source === state.diskSource) return;
-    const wasClean = !state.dirty;
-    state.diskSource = source;
-    state.diskVersion = fingerprint(source);
-    state.lineEnding = detectLineEnding(source);
-    if (wasClean) {
-      state.draftSource = source;
-      state.previewSource = source;
-      state.diagnostics = await diagnosticsFor(sourcePath, source);
-      state.previewVersion += 1;
-      state.revision += 1;
-      state.richProjection = undefined;
-      invalidateArticle(server, articleId);
-    } else {
+    void coordinator.system(async () => {
+      const snapshot = await readStudioFile(requestedSourcePath);
+      if (snapshot.resolvedPath !== sourcePath) {
+        state.conflict = true;
+        state.recoveryConflict = true;
+        state.diagnostics = [sourceTargetChangedDiagnostic()];
+        return { changed: true as const, value: undefined };
+      }
+      const source = snapshot.source;
+      if (snapshot.version === state.diskVersion) {
+        return { changed: false as const, value: undefined };
+      }
+      const wasClean = !state.dirty;
+      state.fileSnapshot = snapshot;
+      state.diskSource = source;
+      state.diskVersion = snapshot.version;
+      state.lineEnding = snapshot.lineEnding;
+      if (wasClean) {
+        state.draftSource = source;
+        state.previewSource = source;
+        state.diagnostics = await diagnosticsFor(compiler, sourcePath, source);
+        state.previewVersion += 1;
+        state.richProjection = undefined;
+        state.recoveryBaseVersion = snapshot.version;
+        state.recovered = false;
+        state.recoveryConflict = false;
+        await reloadArticleSafely(server, articleId, state);
+      } else {
+        state.conflict = true;
+        state.recoveryConflict = true;
+      }
+      return { changed: true as const, value: undefined };
+    }).then(({ changed, revision }) => {
+      state.revision = revision;
+      if (changed) events.publish(revision);
+    }).catch((error: unknown) => {
       state.conflict = true;
-    }
-  });
+      state.diagnostics = [watcherDiagnostic(error)];
+      events.publish(state.revision);
+    });
+  };
+  server.watcher.on("change", handleExternalChange);
+  server.watcher.on("add", handleExternalChange);
   server.watcher.on("unlink", (path) => {
     if (resolve(path) !== sourcePath) return;
-    state.conflict = true;
-    state.diagnostics = [missingSourceDiagnostic()];
+    void coordinator.system(async () => {
+      state.conflict = true;
+      state.diagnostics = [missingSourceDiagnostic()];
+      return { changed: true as const, value: undefined };
+    }).then(({ revision }) => {
+      state.revision = revision;
+      events.publish(revision);
+    });
+  });
+  server.watcher.on("error", (error) => {
+    void coordinator.system(async () => {
+      state.conflict = true;
+      state.diagnostics = [watcherDiagnostic(error)];
+      return { changed: true as const, value: undefined };
+    }).then(({ revision }) => {
+      state.revision = revision;
+      events.publish(revision);
+    });
   });
 
   const address = httpServer.address();
   if (!address || typeof address === "string") {
-    await closeStudioServers(server, httpServer);
+    await closeStudioServers(server, httpServer, compiler);
     throw new Error("Scribe Studio did not expose a local HTTP address.");
   }
   const origin = `http://127.0.0.1:${address.port}`;
+  session.origin = origin;
   if (options.open) openBrowser(origin);
-  return { origin, close: async () => closeStudioServers(server, httpServer) };
+  return {
+    origin,
+    sessionToken: session.token,
+    hasUnsavedChanges: () => state.dirty,
+    close: async () => {
+      events.close();
+      await closeStudioServers(server, httpServer, compiler);
+    }
+  };
 }
 
 export async function runStudio(
@@ -318,6 +458,9 @@ export async function runStudio(
     process.once("SIGINT", stop);
     process.once("SIGTERM", stop);
   });
+  if (handle.hasUnsavedChanges()) {
+    stderr("Studio stopped with an unsaved draft. It was preserved in local recovery storage and will be offered when this article is reopened.\n");
+  }
   await handle.close();
   return 0;
 }
@@ -330,15 +473,21 @@ export function formatStudioStartup(root: string, sourcePath: string, mode: Styl
 function createStudioPlugin(context: {
   readonly root: string;
   readonly sourcePath: string;
+  readonly requestedSourcePath: string;
   readonly hostCss?: string;
   readonly articleId: string;
   readonly runtime: StudioRuntimePaths;
   readonly state: StudioState;
+  readonly coordinator: StudioTransactionCoordinator;
+  readonly session: StudioSession;
+  readonly lease: StudioWriterLease;
+  readonly recovery: StudioRecoveryStore;
+  readonly compiler: StudioCompiler;
+  readonly events: StudioEventHub;
 }): Plugin {
   const previewId = "\0scribe-studio-preview.tsx";
-  const virtualDirectory = dirname(fileURLToPath(import.meta.url));
-  const clientId = normalizePath(resolve(virtualDirectory, "studio-client.virtual.tsx"));
-  const stylesId = normalizePath(resolve(virtualDirectory, "studio-styles.virtual.css"));
+  const clientId = "\0scribe-studio-client.tsx";
+  const stylesId = "\0scribe-studio-styles.css";
   return {
     name: "scribe-studio",
     enforce: "pre",
@@ -356,14 +505,62 @@ function createStudioPlugin(context: {
       if (id === stylesId) return studioStyles();
       return undefined;
     },
+    async transform(code, id) {
+      if (id !== clientId) return undefined;
+      return transformWithOxc(code, "scribe-studio-client.tsx");
+    },
     configureServer(server) {
       server.middlewares.use(async (request, response, next) => {
         const url = new URL(request.url ?? "/", "http://127.0.0.1");
+        if (isStudioMutation(url.pathname, request.method)) {
+          const authorizationError = authorizeStudioMutation(request, context.session);
+          if (authorizationError !== undefined) {
+            return json(response, 403, { error: authorizationError });
+          }
+        }
         if (url.pathname === "/__scribe/api/asset" && request.method === "GET") {
           return json(response, 200, { exists: await publicAssetExists(context.root, url.searchParams.get("path")) });
         }
         if (url.pathname === "/__scribe/api/document" && request.method === "GET") {
           return json(response, 200, publicState(context.state));
+        }
+        if (url.pathname === "/__scribe/api/events" && request.method === "GET") {
+          response.statusCode = 200;
+          response.setHeader("content-type", "text/event-stream; charset=utf-8");
+          response.setHeader("cache-control", "no-store");
+          response.setHeader("connection", "keep-alive");
+          response.write(`data: ${context.state.revision}\n\n`);
+          const unsubscribe = context.events.subscribe((revision) => response.write(`data: ${revision}\n\n`));
+          const unsubscribeClose = context.events.onClose(() => response.end());
+          const heartbeat = setInterval(() => response.write(": keepalive\n\n"), 15_000);
+          request.once("close", () => {
+            clearInterval(heartbeat);
+            unsubscribe();
+            unsubscribeClose();
+          });
+          return;
+        }
+        if (url.pathname === "/__scribe/api/lease" && request.method === "POST") {
+          try {
+            const body = await readJsonBody(request) as Record<string, unknown>;
+            if (typeof body.clientId !== "string" || body.clientId.length < 1 || body.clientId.length > 128) {
+              return json(response, 400, { error: "A writer lease requires a valid clientId." });
+            }
+            const lease = context.lease.acquire(body.clientId);
+            return json(response, lease.granted ? 200 : 423, lease);
+          } catch (error) {
+            return json(response, 400, { error: error instanceof Error ? error.message : String(error) });
+          }
+        }
+        if (url.pathname === "/__scribe/api/lease/release" && request.method === "POST") {
+          try {
+            const body = await readJsonBody(request) as Record<string, unknown>;
+            if (typeof body.clientId !== "string") return json(response, 400, { error: "Lease release requires clientId." });
+            context.lease.release(body.clientId);
+            return json(response, 200, { released: true });
+          } catch (error) {
+            return json(response, 400, { error: error instanceof Error ? error.message : String(error) });
+          }
         }
         if (url.pathname === "/__scribe/api/rich-projection" && request.method === "GET") {
           if (context.state.diagnostics.some(({ severity }) => severity === "error")) {
@@ -385,13 +582,28 @@ function createStudioPlugin(context: {
         }
         if (url.pathname === "/__scribe/api/draft" && request.method === "PUT") {
           try {
-            const body = await readJsonBody(request) as { source?: unknown };
-            if (typeof body.source !== "string") {
-              return json(response, 400, { error: "Draft requires string source." });
+            const body = await readJsonBody(request) as Record<string, unknown>;
+            const mutation = parseMutationRequest(body);
+            if (typeof body.source !== "string" || mutation === undefined) {
+              return json(response, 400, { error: mutationUsage("Draft requires string source.") });
             }
-            await applyDraft(context, server, previewId, normalizeLineEndings(body.source, context.state.lineEnding));
-            context.state.revision += 1;
-            context.state.richProjection = undefined;
+            if (!ensureWriter(context.lease, mutation.clientId)) return writerLocked(response);
+            const result = await context.coordinator.mutate(mutation, async () => {
+              const baseDiskVersion = typeof body.baseDiskVersion === "string"
+                ? body.baseDiskVersion
+                : context.state.recoveryBaseVersion;
+              context.state.recoveryBaseVersion = baseDiskVersion;
+              await applyDraft(context, server, previewId, normalizeLineEndings(body.source as string, context.state.lineEnding));
+              if (body.externalConflict === true || baseDiskVersion !== context.state.diskVersion) {
+                context.state.conflict = true;
+                context.state.recoveryConflict = true;
+              }
+              context.state.richProjection = undefined;
+              return { accepted: true as const, value: undefined };
+            });
+            if (result.kind === "stale") return staleMutation(response, context.state, result);
+            context.state.revision = result.revision;
+            context.events.publish(result.revision);
             const hasErrors = context.state.diagnostics.some(({ severity }) => severity === "error");
             return json(response, 200, { ok: !hasErrors, ...publicState(context.state) });
           } catch (error) {
@@ -400,21 +612,67 @@ function createStudioPlugin(context: {
         }
         if (url.pathname === "/__scribe/api/rich-draft" && request.method === "PUT") {
           try {
-            const body = await readJsonBody(request) as { source?: unknown; revision?: unknown };
-            if (typeof body.source !== "string" || !Number.isInteger(body.revision)) {
-              return json(response, 400, { error: "Rich Text draft requires string source and an integer revision." });
+            const body = await readJsonBody(request) as Record<string, unknown>;
+            const mutation = parseMutationRequest(body);
+            if (typeof body.source !== "string" || mutation === undefined) {
+              return json(response, 400, { error: mutationUsage("Rich Text draft requires string source.") });
             }
-            if (body.revision !== context.state.revision) {
+            if (!ensureWriter(context.lease, mutation.clientId)) return writerLocked(response);
+            const transaction = await context.coordinator.mutate<RichMutationValue>(mutation, async () => {
+              const baseSource = typeof body.baseSource === "string" ? body.baseSource : context.state.draftSource;
+              const baseDiskVersion = typeof body.baseDiskVersion === "string"
+                ? body.baseDiskVersion
+                : context.state.recoveryBaseVersion;
+              const projection = baseSource === context.state.draftSource
+                ? await ensureRichProjection(context.state)
+                : await createRichProjection(baseSource);
+              let acceptedDiagnostics: StudioDiagnostic[] = [];
+              const result = await acceptRichCandidate(
+                projection,
+                body.source as string,
+                context.sourcePath,
+                async ({ path, value }) => {
+                  acceptedDiagnostics = await context.compiler.compile(path, value);
+                  const error = acceptedDiagnostics.find(({ severity }) => severity === "error");
+                  if (error !== undefined) {
+                    throw Object.assign(new Error(error.message), {
+                      ruleId: error.code,
+                      ...(error.line === undefined ? {} : { line: error.line }),
+                      ...(error.column === undefined ? {} : { column: error.column })
+                    });
+                  }
+                }
+              );
+              if (!result.ok) return { accepted: false as const, value: { result, projection } };
+              context.state.recoveryBaseVersion = baseDiskVersion;
+              await applyDraft(
+                context,
+                server,
+                previewId,
+                normalizeLineEndings(result.markdown, context.state.lineEnding),
+                acceptedDiagnostics
+              );
+              if (baseDiskVersion !== context.state.diskVersion) {
+                context.state.conflict = true;
+                context.state.recoveryConflict = true;
+              }
+              const nextProjection = await createRichProjection(context.state.draftSource);
+              context.state.richProjection = nextProjection;
+              return { accepted: true as const, value: { result, projection: nextProjection } };
+            });
+            if (transaction.kind === "stale") {
               return json(response, 409, {
                 ok: false,
                 code: "SCB_RICH_STALE_PROJECTION",
                 error: "The Markdown draft changed after Rich Text mode opened. Reload Rich Text from the current draft.",
-                ...publicState(context.state)
+                ...publicStateWithRevision(context.state, transaction.revision)
               });
             }
-            const projection = await ensureRichProjection(context.state);
-            const result = await acceptRichCandidate(projection, body.source, context.sourcePath);
-            if (!result.ok) {
+            context.state.revision = transaction.revision;
+            context.events.publish(transaction.revision);
+            if (transaction.kind === "rejected") {
+              const { result, projection } = transaction.value;
+              if (result.ok) throw new Error("Studio rejected an accepted Rich Text candidate.");
               return json(response, 422, {
                 ok: false,
                 code: result.code,
@@ -425,13 +683,10 @@ function createStudioPlugin(context: {
                 ...publicState(context.state)
               });
             }
-            await applyDraft(context, server, previewId, normalizeLineEndings(result.markdown, context.state.lineEnding));
-            context.state.revision += 1;
-            context.state.richProjection = await createRichProjection(context.state.draftSource);
             return json(response, 200, {
               ok: true,
-              projectionMarkdown: context.state.richProjection.projectionMarkdown,
-              islands: context.state.richProjection.islands,
+              projectionMarkdown: transaction.value.projection.projectionMarkdown,
+              islands: transaction.value.projection.islands,
               ...publicState(context.state)
             });
           } catch (error) {
@@ -440,66 +695,176 @@ function createStudioPlugin(context: {
         }
         if (url.pathname === "/__scribe/api/save" && request.method === "PUT") {
           try {
-            const body = await readJsonBody(request) as { expectedDiskVersion?: unknown };
-            let diskSource: string;
-            try {
-              diskSource = await readUtf8(context.sourcePath);
-            } catch {
-              context.state.conflict = true;
-              context.state.diagnostics = [missingSourceDiagnostic()];
-              return json(response, 409, {
-                error: "The source file was deleted or renamed outside Studio. Restore it before saving.",
-                ...publicState(context.state)
+            const body = await readJsonBody(request) as Record<string, unknown>;
+            const mutation = parseMutationRequest(body);
+            if (mutation === undefined) return json(response, 400, { error: mutationUsage("Save requires expectedDiskVersion.") });
+            if (!ensureWriter(context.lease, mutation.clientId)) return writerLocked(response);
+            const transaction = await context.coordinator.mutate<StudioMutationHttpResult>(mutation, async () => {
+              let diskSnapshot: StudioFileSnapshot;
+              try {
+                diskSnapshot = await readStudioFile(context.requestedSourcePath);
+              } catch {
+                context.state.conflict = true;
+                context.state.diagnostics = [missingSourceDiagnostic()];
+                return { accepted: true as const, value: { status: 409, error: "The source file was deleted or renamed outside Studio. Restore it before saving." } };
+              }
+              if (diskSnapshot.resolvedPath !== context.sourcePath) {
+                context.state.conflict = true;
+                context.state.recoveryConflict = true;
+                context.state.diagnostics = [sourceTargetChangedDiagnostic()];
+                return { accepted: true as const, value: { status: 409, error: "The source symlink or file target changed outside Studio. The unsaved draft was not written." } };
+              }
+              if (
+                body.expectedDiskVersion !== context.state.diskVersion
+                || context.state.conflict
+                || diskSnapshot.version !== body.expectedDiskVersion
+              ) {
+                context.state.fileSnapshot = diskSnapshot;
+                context.state.diskSource = diskSnapshot.source;
+                context.state.diskVersion = diskSnapshot.version;
+                context.state.lineEnding = diskSnapshot.lineEnding;
+                context.state.conflict = true;
+                return { accepted: true as const, value: { status: 409, error: "The source changed outside Studio. Reload or reconcile before saving." } };
+              }
+              await context.recovery.writeHistory({
+                sourcePath: context.sourcePath,
+                baseDiskVersion: diskSnapshot.version,
+                draftSource: diskSnapshot.source,
+                revision: context.coordinator.revision
+              }, "checkpoint");
+              const committed = await durableWriteStudioFile({
+                requestedPath: context.requestedSourcePath,
+                resolvedPath: diskSnapshot.resolvedPath,
+                expectedVersion: diskSnapshot.version,
+                expectedDevice: diskSnapshot.device,
+                expectedInode: diskSnapshot.inode,
+                source: context.state.draftSource,
+                lineEnding: diskSnapshot.lineEnding,
+                bom: diskSnapshot.bom,
+                mode: diskSnapshot.mode
               });
-            }
-            const diskVersion = fingerprint(diskSource);
-            if (body.expectedDiskVersion !== context.state.diskVersion || context.state.conflict || diskVersion !== body.expectedDiskVersion) {
-              context.state.diskSource = diskSource;
-              context.state.diskVersion = diskVersion;
-              context.state.lineEnding = detectLineEnding(diskSource);
-              context.state.conflict = true;
-              return json(response, 409, { error: "The source changed outside Studio. Reload or reconcile before saving.", ...publicState(context.state) });
-            }
-            await atomicWrite(context.sourcePath, context.state.draftSource);
-            context.state.diskSource = context.state.draftSource;
-            context.state.diskVersion = fingerprint(context.state.diskSource);
-            context.state.dirty = false;
-            context.state.conflict = false;
-            return json(response, 200, { ok: true, ...publicState(context.state) });
+              context.state.fileSnapshot = committed;
+              context.state.diskSource = committed.source;
+              context.state.diskVersion = committed.version;
+              context.state.lineEnding = committed.lineEnding;
+              context.state.dirty = false;
+              context.state.conflict = false;
+              context.state.recoveryBaseVersion = committed.version;
+              context.state.recovered = false;
+              context.state.recoveryConflict = false;
+              context.state.discardRecoveryAvailable = false;
+              await context.recovery.archiveDraft("saved").catch(() => undefined);
+              return { accepted: true as const, value: { status: 200 } };
+            });
+            if (transaction.kind === "stale") return staleMutation(response, context.state, transaction);
+            context.state.revision = transaction.revision;
+            context.events.publish(transaction.revision);
+            return json(response, transaction.value.status, {
+              ok: transaction.value.status === 200,
+              ...(transaction.value.error === undefined ? {} : { error: transaction.value.error }),
+              ...publicState(context.state)
+            });
           } catch (error) {
+            if (error instanceof StudioFileConflictError) {
+              context.state.conflict = true;
+              return json(response, 409, { error: error.message, ...publicState(context.state) });
+            }
             return json(response, 500, { error: error instanceof Error ? error.message : String(error) });
           }
         }
         if (url.pathname === "/__scribe/api/discard" && request.method === "POST") {
-          let diskSource: string;
           try {
-            diskSource = await readUtf8(context.sourcePath);
-          } catch {
-            context.state.conflict = true;
-            context.state.diagnostics = [missingSourceDiagnostic()];
-            return json(response, 409, {
-              error: "The source file was deleted or renamed outside Studio. The unsaved draft is still preserved.",
+            const body = await readJsonBody(request) as Record<string, unknown>;
+            const mutation = parseMutationRequest(body);
+            if (mutation === undefined) return json(response, 400, { error: mutationUsage("Discard requires a mutation envelope.") });
+            if (!ensureWriter(context.lease, mutation.clientId)) return writerLocked(response);
+            const transaction = await context.coordinator.mutate<StudioMutationHttpResult>(mutation, async () => {
+              let diskSnapshot: StudioFileSnapshot;
+              try {
+                diskSnapshot = await readStudioFile(context.requestedSourcePath);
+              } catch {
+                context.state.conflict = true;
+                context.state.diagnostics = [missingSourceDiagnostic()];
+                return { accepted: true as const, value: { status: 409, error: "The source file was deleted or renamed outside Studio. The unsaved draft is still preserved." } };
+              }
+              if (diskSnapshot.resolvedPath !== context.sourcePath) {
+                context.state.conflict = true;
+                context.state.recoveryConflict = true;
+                context.state.diagnostics = [sourceTargetChangedDiagnostic()];
+                return { accepted: true as const, value: { status: 409, error: "The source symlink or file target changed outside Studio. The unsaved draft is still preserved." } };
+              }
+              const archived = await context.recovery.archiveDraft("discarded");
+              context.state.fileSnapshot = diskSnapshot;
+              context.state.diskSource = diskSnapshot.source;
+              context.state.diskVersion = diskSnapshot.version;
+              context.state.lineEnding = diskSnapshot.lineEnding;
+              context.state.draftSource = diskSnapshot.source;
+              context.state.previewSource = diskSnapshot.source;
+              context.state.dirty = false;
+              context.state.conflict = false;
+              context.state.diagnostics = await diagnosticsFor(context.compiler, context.sourcePath, diskSnapshot.source);
+              context.state.previewVersion += 1;
+              context.state.richProjection = undefined;
+              context.state.recoveryBaseVersion = diskSnapshot.version;
+              context.state.recovered = false;
+              context.state.recoveryConflict = false;
+              context.state.discardRecoveryAvailable = archived !== undefined;
+              await reloadArticleSafely(server, context.articleId, context.state);
+              return { accepted: true as const, value: { status: 200 } };
+            });
+            if (transaction.kind === "stale") return staleMutation(response, context.state, transaction);
+            context.state.revision = transaction.revision;
+            context.events.publish(transaction.revision);
+            return json(response, transaction.value.status, {
+              ok: transaction.value.status === 200,
+              ...(transaction.value.error === undefined ? {} : { error: transaction.value.error }),
               ...publicState(context.state)
             });
+          } catch (error) {
+            return json(response, 400, { error: error instanceof Error ? error.message : String(error) });
           }
-          context.state.diskSource = diskSource;
-          context.state.diskVersion = fingerprint(diskSource);
-          context.state.lineEnding = detectLineEnding(diskSource);
-          context.state.draftSource = diskSource;
-          context.state.previewSource = diskSource;
-          context.state.dirty = false;
-          context.state.conflict = false;
-          context.state.diagnostics = await diagnosticsFor(context.sourcePath, diskSource);
-          context.state.previewVersion += 1;
-          context.state.revision += 1;
-          context.state.richProjection = undefined;
-          invalidateArticle(server, context.articleId);
-          return json(response, 200, { ok: true, ...publicState(context.state) });
+        }
+        if (url.pathname === "/__scribe/api/recover-discard" && request.method === "POST") {
+          try {
+            const body = await readJsonBody(request) as Record<string, unknown>;
+            const mutation = parseMutationRequest(body);
+            if (mutation === undefined) return json(response, 400, { error: mutationUsage("Recovery requires a mutation envelope.") });
+            if (!ensureWriter(context.lease, mutation.clientId)) return writerLocked(response);
+            const transaction = await context.coordinator.mutate<StudioMutationHttpResult>(mutation, async () => {
+              const archived = await context.recovery.loadLatestArchive("discarded");
+              if (archived === undefined || archived.sourcePath !== context.sourcePath) {
+                return { accepted: false as const, value: { status: 404, error: "No discarded Studio draft is available to recover." } };
+              }
+              const previousBase = context.state.recoveryBaseVersion;
+              context.state.recoveryBaseVersion = archived.baseDiskVersion;
+              try {
+                await applyDraft(context, server, previewId, archived.draftSource);
+              } catch (error) {
+                context.state.recoveryBaseVersion = previousBase;
+                throw error;
+              }
+              context.state.recovered = true;
+              context.state.recoveryConflict = archived.baseDiskVersion !== context.state.diskVersion;
+              context.state.conflict ||= context.state.recoveryConflict;
+              context.state.discardRecoveryAvailable = false;
+              return { accepted: true as const, value: { status: 200 } };
+            });
+            if (transaction.kind === "stale") return staleMutation(response, context.state, transaction);
+            context.state.revision = transaction.revision;
+            context.events.publish(transaction.revision);
+            return json(response, transaction.value.status, {
+              ok: transaction.kind === "accepted",
+              ...(transaction.value.error === undefined ? {} : { error: transaction.value.error }),
+              ...publicState(context.state)
+            });
+          } catch (error) {
+            return json(response, 400, { error: error instanceof Error ? error.message : String(error) });
+          }
         }
         if (url.pathname === "/" || url.pathname === "/studio") {
           response.statusCode = 200;
           response.setHeader("content-type", "text/html; charset=utf-8");
-          response.end(await server.transformIndexHtml(url.pathname, studioHtml()));
+          response.end(await server.transformIndexHtml(url.pathname, studioHtml(context.session.token)));
           return;
         }
         if (url.pathname === "/preview") {
@@ -655,12 +1020,21 @@ if (!matchMedia("(prefers-reduced-motion: reduce)").matches) {
   new Lenis({ autoRaf: true, smoothWheel: true, gestureOrientation: "vertical", anchors: true });
 }
 const components = createScribeComponents({ components: { wrapper: Wrapper, Banner: StudioBanner, img: StudioImage } });
-createRoot(document.querySelector("#preview")).render(React.createElement(Article, { components }));
+const previewRoot = createRoot(document.querySelector("#preview"));
+function renderArticle(ArticleComponent) {
+  previewRoot.render(React.createElement(ArticleComponent, { components }));
+}
+renderArticle(Article);
+if (import.meta.hot) {
+  import.meta.hot.accept("virtual:scribe-studio-article", (module) => {
+    if (module?.default) renderArticle(module.default);
+  });
+}
 `;
 }
 
-function studioHtml(): string {
-  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Scribe Studio</title></head><body><div id="scribe-studio"></div><script type="module" src="/@scribe-studio/client.tsx"></script></body></html>`;
+function studioHtml(sessionToken: string): string {
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="scribe-studio-session" content="${sessionToken}"><title>Scribe Studio</title></head><body><div id="scribe-studio"></div><script type="module" src="/@scribe-studio/client.tsx"></script></body></html>`;
 }
 
 function previewHtml(): string {
@@ -677,10 +1051,73 @@ function publicState(state: StudioState) {
     modeReason: state.modeReason,
     dirty: state.dirty,
     conflict: state.conflict,
+    recovered: state.recovered,
+    recoveryConflict: state.recoveryConflict,
+    discardRecoveryAvailable: state.discardRecoveryAvailable,
+    recoveryKey: state.recoveryKey,
     diagnostics: state.diagnostics,
     revision: state.revision,
     frontmatter: frontmatter(state.draftSource)
   };
+}
+
+function publicStateWithRevision(state: StudioState, revision: number) {
+  return { ...publicState(state), revision };
+}
+
+function isStudioMutation(pathname: string, method: string | undefined): boolean {
+  return (method === "PUT" || method === "POST") && pathname.startsWith("/__scribe/api/");
+}
+
+function parseMutationRequest(body: Record<string, unknown>): StudioMutationRequest | undefined {
+  if (
+    typeof body.clientId !== "string"
+    || body.clientId.length < 1
+    || body.clientId.length > 128
+    || typeof body.operationId !== "string"
+    || body.operationId.length < 1
+    || body.operationId.length > 128
+    || !Number.isSafeInteger(body.baseRevision)
+    || (body.baseRevision as number) < 0
+  ) {
+    return undefined;
+  }
+  return {
+    clientId: body.clientId,
+    operationId: body.operationId,
+    baseRevision: body.baseRevision as number
+  };
+}
+
+function mutationUsage(prefix: string): string {
+  return `${prefix} Include clientId, operationId, and integer baseRevision from the current Studio document.`;
+}
+
+function ensureWriter(lease: StudioWriterLease, clientId: string): boolean {
+  return lease.holds(clientId) || lease.acquire(clientId).granted;
+}
+
+function writerLocked(response: import("node:http").ServerResponse): void {
+  json(response, 423, {
+    ok: false,
+    code: "SCB_STUDIO_WRITER_LOCKED",
+    error: "Another Studio tab currently owns this draft. This tab remains read-only until that writer disconnects."
+  });
+}
+
+function staleMutation(
+  response: import("node:http").ServerResponse,
+  state: StudioState,
+  result: Extract<StudioMutationResult<unknown>, { readonly kind: "stale" }>
+): void {
+  json(response, 409, {
+    ok: false,
+    code: "SCB_STUDIO_STALE_REVISION",
+    error: state.conflict
+      ? "The source changed outside Studio. Reload or reconcile before retrying."
+      : "The Studio draft changed before this operation was applied. Reload the current draft and retry.",
+    ...publicStateWithRevision(state, result.revision)
+  });
 }
 
 async function ensureRichProjection(state: StudioState): Promise<RichProjection> {
@@ -689,42 +1126,46 @@ async function ensureRichProjection(state: StudioState): Promise<RichProjection>
 }
 
 async function applyDraft(
-  context: { readonly sourcePath: string; readonly articleId: string; readonly state: StudioState },
+  context: {
+    readonly sourcePath: string;
+    readonly articleId: string;
+    readonly state: StudioState;
+    readonly coordinator: StudioTransactionCoordinator;
+    readonly recovery: StudioRecoveryStore;
+    readonly compiler: StudioCompiler;
+  },
   server: ViteDevServer,
   previewId: string,
-  source: string
+  source: string,
+  knownDiagnostics?: StudioDiagnostic[]
 ): Promise<void> {
+  const dirty = source !== context.state.diskSource;
+  const diagnostics = knownDiagnostics ?? await diagnosticsFor(context.compiler, context.sourcePath, source);
+  if (dirty) {
+    await context.recovery.writeDraft({
+      sourcePath: context.sourcePath,
+      baseDiskVersion: context.state.recoveryBaseVersion,
+      draftSource: source,
+      revision: context.coordinator.revision + 1
+    });
+  } else {
+    await context.recovery.archiveDraft("reverted");
+  }
   context.state.draftSource = source;
-  context.state.dirty = source !== context.state.diskSource;
-  context.state.diagnostics = await diagnosticsFor(context.sourcePath, source);
-  if (context.state.diagnostics.some(({ severity }) => severity === "error")) return;
+  context.state.dirty = dirty;
+  context.state.diagnostics = diagnostics;
+  context.state.recovered = false;
+  context.state.recoveryConflict = context.state.conflict;
+  if (diagnostics.some(({ severity }) => severity === "error")) return;
   context.state.previewSource = source;
   context.state.previewVersion += 1;
-  invalidateArticle(server, context.articleId);
+  await reloadArticleSafely(server, context.articleId, context.state);
   const preview = server.moduleGraph.getModuleById(previewId);
   if (preview) server.moduleGraph.invalidateModule(preview);
 }
 
-async function diagnosticsFor(path: string, source: string): Promise<StudioDiagnostic[]> {
-  try {
-    const file = await compileScribeMdx({ path, value: source });
-    return file.messages.map((message) => ({
-      severity: "warning" as const,
-      code: message.ruleId ?? "SCB0001",
-      message: message.reason,
-      ...(message.line === undefined ? {} : { line: message.line }),
-      ...(message.column === undefined ? {} : { column: message.column })
-    }));
-  } catch (error) {
-    const diagnostic = error as { reason?: string; message?: string; ruleId?: string; line?: number; column?: number };
-    return [{
-      severity: "error",
-      code: diagnostic.ruleId ?? "SCB0001",
-      message: diagnostic.reason ?? diagnostic.message ?? String(error),
-      ...(diagnostic.line === undefined ? {} : { line: diagnostic.line }),
-      ...(diagnostic.column === undefined ? {} : { column: diagnostic.column })
-    }];
-  }
+async function diagnosticsFor(compiler: StudioCompiler, path: string, source: string): Promise<StudioDiagnostic[]> {
+  return compiler.compile(path, source);
 }
 
 function frontmatter(source: string): Record<string, string> {
@@ -740,10 +1181,6 @@ function normalizeLineEndings(source: string, ending: "\n" | "\r\n"): string {
   return source.replace(/\r\n?|\n/gu, "\n").replaceAll("\n", ending);
 }
 
-function detectLineEnding(source: string): "\n" | "\r\n" {
-  return source.includes("\r\n") ? "\r\n" : "\n";
-}
-
 function missingSourceDiagnostic(): StudioDiagnostic {
   return {
     severity: "error",
@@ -752,17 +1189,28 @@ function missingSourceDiagnostic(): StudioDiagnostic {
   };
 }
 
-async function readUtf8(path: string): Promise<string> {
-  const bytes = await readFile(path);
-  try {
-    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-  } catch {
-    throw new Error(`Studio could not decode ${path} as UTF-8.`);
-  }
+function watcherDiagnostic(error: unknown): StudioDiagnostic {
+  return {
+    severity: "error",
+    code: "SCB2002",
+    message: `Studio could not process an external source change: ${error instanceof Error ? error.message : String(error)}`
+  };
 }
 
-function fingerprint(source: string): string {
-  return createHash("sha256").update(source).digest("hex");
+function sourceTargetChangedDiagnostic(): StudioDiagnostic {
+  return {
+    severity: "error",
+    code: "SCB2003",
+    message: "The source symlink or file target changed outside Studio. The current draft is preserved, but saving is blocked."
+  };
+}
+
+function previewReloadDiagnostic(error: unknown): StudioDiagnostic {
+  return {
+    severity: "warning",
+    code: "SCB2004",
+    message: `The draft is preserved, but Studio could not refresh the preview: ${error instanceof Error ? error.message : String(error)}`
+  };
 }
 
 function assertWithinWorkspace(root: string, path: string, label: string): void {
@@ -780,23 +1228,25 @@ async function publicAssetExists(root: string, requestedPath: string | null): Pr
   const assetPath = resolve(publicRoot, `.${requestedPath}`);
   try {
     assertWithinWorkspace(publicRoot, assetPath, "Public asset");
-    return (await stat(assetPath)).isFile();
+    const [resolvedPublicRoot, resolvedAssetPath] = await Promise.all([realpath(publicRoot), realpath(assetPath)]);
+    assertWithinWorkspace(resolvedPublicRoot, resolvedAssetPath, "Resolved public asset");
+    return (await stat(resolvedAssetPath)).isFile();
   } catch {
     return false;
   }
 }
 
-async function atomicWrite(path: string, content: string): Promise<void> {
-  const info = await stat(path);
-  const temporary = `${path}.scribe-${process.pid}-${Math.random().toString(16).slice(2)}.tmp`;
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(temporary, content, { encoding: "utf8", mode: info.mode });
-  await rename(temporary, path);
+async function reloadArticle(server: ViteDevServer, articleId: string): Promise<void> {
+  const module = server.moduleGraph.getModuleById(articleId);
+  if (module) await server.reloadModule(module);
 }
 
-function invalidateArticle(server: ViteDevServer, articleId: string): void {
-  const module = server.moduleGraph.getModuleById(articleId);
-  if (module) server.moduleGraph.invalidateModule(module);
+async function reloadArticleSafely(server: ViteDevServer, articleId: string, state: StudioState): Promise<void> {
+  try {
+    await reloadArticle(server, articleId);
+  } catch (error) {
+    state.diagnostics = [...state.diagnostics, previewReloadDiagnostic(error)];
+  }
 }
 
 async function readJsonBody(request: import("node:http").IncomingMessage): Promise<unknown> {
@@ -838,13 +1288,32 @@ async function listenOnLoopback(server: HttpServer, port: number): Promise<void>
   });
 }
 
-async function closeStudioServers(vite: ViteDevServer, http: HttpServer): Promise<void> {
+async function closeStudioServers(vite: ViteDevServer, http: HttpServer, compiler: StudioCompiler): Promise<void> {
+  http.closeIdleConnections();
+  http.closeAllConnections();
+  const httpClosed = !http.listening
+    ? Promise.resolve()
+    : new Promise<void>((resolveClose, rejectClose) => {
+        http.close((error) => error === undefined ? resolveClose() : rejectClose(error));
+      });
   try {
-    await vite.close();
+    await shutdownStep(compiler.close(), "compiler worker");
+    await shutdownStep(vite.close(), "Vite server");
   } finally {
-    if (!http.listening) return;
-    await new Promise<void>((resolveClose, rejectClose) => {
-      http.close((error) => error === undefined ? resolveClose() : rejectClose(error));
-    });
+    await shutdownStep(httpClosed, "Studio HTTP server");
+  }
+}
+
+async function shutdownStep(operation: Promise<unknown>, label: string): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      operation,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`Timed out closing the ${label}.`)), 3_000);
+      })
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
   }
 }

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -34,7 +34,7 @@ import {
   type RichProjection
 } from "./rich-preservation.js";
 import { StudioWriterLease } from "./studio-lease.js";
-import { StudioRecoveryStore, studioRecoveryKey } from "./studio-recovery.js";
+import { StudioRecoveryStore, studioRecoveryKey, type StudioRecoveryRecord } from "./studio-recovery.js";
 import { authorizeStudioMutation, createStudioSession, studioSessionHeader, type StudioSession } from "./studio-security.js";
 import {
   StudioTransactionCoordinator,
@@ -195,12 +195,23 @@ export async function startStudio(options: StudioOptions): Promise<StudioHandle>
   }
 
   const recovery = new StudioRecoveryStore(sourcePath, options.recoveryRoot);
-  const recoveredDraft = await recovery.loadDraft();
+  let recoveredDraft: StudioRecoveryRecord | undefined;
+  try {
+    recoveredDraft = await recovery.loadDraft();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    throw new Error(
+      `Studio could not read its local recovery state${code === undefined ? "" : ` (${code})`}. Check the recovery directory permissions before reopening this article.`
+    );
+  }
   const runtime = studioRuntimePaths();
   const compiler = new StudioCompiler();
-  const canRecover = recoveredDraft?.sourcePath === sourcePath && recoveredDraft.draftSource !== fileSnapshot.source;
+  const recoveryDraft = recoveredDraft?.sourcePath === sourcePath && recoveredDraft.draftSource !== fileSnapshot.source
+    ? recoveredDraft
+    : undefined;
+  const canRecover = recoveryDraft !== undefined;
   const diskSource = fileSnapshot.source;
-  const draftSource = canRecover ? recoveredDraft.draftSource : diskSource;
+  const draftSource = recoveryDraft?.draftSource ?? diskSource;
   let initialDiagnostics: StudioDiagnostic[];
   try {
     initialDiagnostics = await diagnosticsFor(compiler, sourcePath, draftSource);
@@ -220,14 +231,14 @@ export async function startStudio(options: StudioOptions): Promise<StudioHandle>
     modeReason: options.modeReason ?? "Selected explicitly by the Studio caller.",
     lineEnding: fileSnapshot.lineEnding,
     dirty: draftSource !== diskSource,
-    conflict: Boolean(canRecover && recoveredDraft.baseDiskVersion !== fileSnapshot.version),
+    conflict: Boolean(recoveryDraft && recoveryDraft.baseDiskVersion !== fileSnapshot.version),
     diagnostics: initialDiagnostics,
-    revision: canRecover ? Math.max(1, recoveredDraft.revision) : 1,
+    revision: recoveryDraft ? Math.max(1, recoveryDraft.revision) : 1,
     richProjection: undefined,
     fileSnapshot,
-    recoveryBaseVersion: canRecover ? recoveredDraft.baseDiskVersion : fileSnapshot.version,
+    recoveryBaseVersion: recoveryDraft?.baseDiskVersion ?? fileSnapshot.version,
     recovered: Boolean(canRecover),
-    recoveryConflict: Boolean(canRecover && recoveredDraft.baseDiskVersion !== fileSnapshot.version),
+    recoveryConflict: Boolean(recoveryDraft && recoveryDraft.baseDiskVersion !== fileSnapshot.version),
     discardRecoveryAvailable: false,
     recoveryKey: studioRecoveryKey(sourcePath)
   };
@@ -318,7 +329,15 @@ export async function startStudio(options: StudioOptions): Promise<StudioHandle>
   const handleExternalChange = (path: string) => {
     if (resolve(path) !== sourcePath) return;
     void coordinator.system(async (nextRevision) => {
-      const snapshot = await readStudioFile(requestedSourcePath);
+      let snapshot: StudioFileSnapshot;
+      try {
+        snapshot = await readStudioFile(requestedSourcePath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          return { changed: false as const, value: undefined };
+        }
+        throw error;
+      }
       if (snapshot.resolvedPath !== sourcePath) {
         state.revision = nextRevision;
         state.conflict = true;

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -317,9 +317,10 @@ export async function startStudio(options: StudioOptions): Promise<StudioHandle>
   server.watcher.add(sourcePath);
   const handleExternalChange = (path: string) => {
     if (resolve(path) !== sourcePath) return;
-    void coordinator.system(async () => {
+    void coordinator.system(async (nextRevision) => {
       const snapshot = await readStudioFile(requestedSourcePath);
       if (snapshot.resolvedPath !== sourcePath) {
+        state.revision = nextRevision;
         state.conflict = true;
         state.recoveryConflict = true;
         state.diagnostics = [sourceTargetChangedDiagnostic()];
@@ -330,6 +331,10 @@ export async function startStudio(options: StudioOptions): Promise<StudioHandle>
         return { changed: false as const, value: undefined };
       }
       const wasClean = !state.dirty;
+      const diagnostics = wasClean
+        ? await diagnosticsFor(compiler, sourcePath, source)
+        : state.diagnostics;
+      state.revision = nextRevision;
       state.fileSnapshot = snapshot;
       state.diskSource = source;
       state.diskVersion = snapshot.version;
@@ -337,7 +342,7 @@ export async function startStudio(options: StudioOptions): Promise<StudioHandle>
       if (wasClean) {
         state.draftSource = source;
         state.previewSource = source;
-        state.diagnostics = await diagnosticsFor(compiler, sourcePath, source);
+        state.diagnostics = diagnostics;
         state.previewVersion += 1;
         state.richProjection = undefined;
         state.recoveryBaseVersion = snapshot.version;
@@ -362,7 +367,8 @@ export async function startStudio(options: StudioOptions): Promise<StudioHandle>
   server.watcher.on("add", handleExternalChange);
   server.watcher.on("unlink", (path) => {
     if (resolve(path) !== sourcePath) return;
-    void coordinator.system(async () => {
+    void coordinator.system(async (nextRevision) => {
+      state.revision = nextRevision;
       state.conflict = true;
       state.diagnostics = [missingSourceDiagnostic()];
       return { changed: true as const, value: undefined };
@@ -372,7 +378,8 @@ export async function startStudio(options: StudioOptions): Promise<StudioHandle>
     });
   });
   server.watcher.on("error", (error) => {
-    void coordinator.system(async () => {
+    void coordinator.system(async (nextRevision) => {
+      state.revision = nextRevision;
       state.conflict = true;
       state.diagnostics = [watcherDiagnostic(error)];
       return { changed: true as const, value: undefined };

--- a/packages/mdx/README.md
+++ b/packages/mdx/README.md
@@ -6,7 +6,7 @@ Scribe is an open-source publishing SDK that turns ordinary Markdown, MDX, seman
 
 Scribe is for developers who already own a React website built with Next.js or Vite and want publication-grade typography, code, tables, banners, callouts, figures, responsive behavior, and accessibility without assembling a publishing design system themselves. It transforms semantic article content at build time and renders it through a small React component map plus scoped CSS.
 
-Scribe is not a hosted blogging platform, CMS, website builder, rich-text editor, proprietary content format, collaboration service, or replacement for React, Next.js, MDX, routing, deployment, analytics, or content storage. The public alpha is tested against React 19.2.7, Next.js 16.2.10, Vite 8.1.3, and MDX 3.1.1. Broader compatibility will be validated through real integrations.
+Scribe is not a hosted blogging platform, CMS, website builder, rich-text editor, proprietary content format, collaboration service, or replacement for React, Next.js, MDX, routing, deployment, analytics, or content storage. The public alpha is tested against React 19.2.7, Next.js 16.2.11, Vite 8.1.3, and MDX 3.1.1. Broader compatibility will be validated through real integrations.
 
 ## Packages
 
@@ -117,10 +117,10 @@ Initialization is minimal and idempotent. It does not replace existing remark/re
 
 ## Next.js MDX integration
 
-The tested Next.js path uses Next 16.2.10 and React 19.2.7. Install Next’s MDX integration if the host does not already have it:
+The tested Next.js path uses Next 16.2.11 and React 19.2.7. Install Next’s MDX integration if the host does not already have it:
 
 ```bash
-bun add @next/mdx@16.2.10 @mdx-js/loader@3.1.1 @mdx-js/react@3.1.1
+bun add @next/mdx@16.2.11 @mdx-js/loader@3.1.1 @mdx-js/react@3.1.1
 ```
 
 Configure the shared Scribe compiler in `next.config.mjs`:
@@ -460,7 +460,7 @@ Scribe owns publication structure, semantic component mappings, responsive artic
 
 The current public-alpha matrix uses fresh packed tarballs for installation, strict typechecking, and production-build claims:
 
-- Framework integrations: React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.10, `@next/mdx` 16.2.10, and `next-mdx-remote` 6.0.0.
+- Framework integrations: React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.11, `@next/mdx` 16.2.11, and `next-mdx-remote` 6.0.0.
 - Declarations: TypeScript 7.0.2 and 6.0.2 with `skipLibCheck: false`.
 - Package and CLI portability: Linux, Windows, and macOS using Bun 1.3.13 and an npm-compatible install flow.
 - Browser behavior: current Playwright-managed Chromium and Firefox, including console errors, uncaught page errors, host isolation, and narrow-viewport overflow.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -6,7 +6,7 @@ Scribe is an open-source publishing SDK that turns ordinary Markdown, MDX, seman
 
 Scribe is for developers who already own a React website built with Next.js or Vite and want publication-grade typography, code, tables, banners, callouts, figures, responsive behavior, and accessibility without assembling a publishing design system themselves. It transforms semantic article content at build time and renders it through a small React component map plus scoped CSS.
 
-Scribe is not a hosted blogging platform, CMS, website builder, rich-text editor, proprietary content format, collaboration service, or replacement for React, Next.js, MDX, routing, deployment, analytics, or content storage. The public alpha is tested against React 19.2.7, Next.js 16.2.10, Vite 8.1.3, and MDX 3.1.1. Broader compatibility will be validated through real integrations.
+Scribe is not a hosted blogging platform, CMS, website builder, rich-text editor, proprietary content format, collaboration service, or replacement for React, Next.js, MDX, routing, deployment, analytics, or content storage. The public alpha is tested against React 19.2.7, Next.js 16.2.11, Vite 8.1.3, and MDX 3.1.1. Broader compatibility will be validated through real integrations.
 
 ## Packages
 
@@ -117,10 +117,10 @@ Initialization is minimal and idempotent. It does not replace existing remark/re
 
 ## Next.js MDX integration
 
-The tested Next.js path uses Next 16.2.10 and React 19.2.7. Install Next’s MDX integration if the host does not already have it:
+The tested Next.js path uses Next 16.2.11 and React 19.2.7. Install Next’s MDX integration if the host does not already have it:
 
 ```bash
-bun add @next/mdx@16.2.10 @mdx-js/loader@3.1.1 @mdx-js/react@3.1.1
+bun add @next/mdx@16.2.11 @mdx-js/loader@3.1.1 @mdx-js/react@3.1.1
 ```
 
 Configure the shared Scribe compiler in `next.config.mjs`:
@@ -460,7 +460,7 @@ Scribe owns publication structure, semantic component mappings, responsive artic
 
 The current public-alpha matrix uses fresh packed tarballs for installation, strict typechecking, and production-build claims:
 
-- Framework integrations: React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.10, `@next/mdx` 16.2.10, and `next-mdx-remote` 6.0.0.
+- Framework integrations: React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.11, `@next/mdx` 16.2.11, and `next-mdx-remote` 6.0.0.
 - Declarations: TypeScript 7.0.2 and 6.0.2 with `skipLibCheck: false`.
 - Package and CLI portability: Linux, Windows, and macOS using Bun 1.3.13 and an npm-compatible install flow.
 - Browser behavior: current Playwright-managed Chromium and Firefox, including console errors, uncaught page errors, host isolation, and narrow-viewport overflow.

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -6,7 +6,7 @@ Scribe is an open-source publishing SDK that turns ordinary Markdown, MDX, seman
 
 Scribe is for developers who already own a React website built with Next.js or Vite and want publication-grade typography, code, tables, banners, callouts, figures, responsive behavior, and accessibility without assembling a publishing design system themselves. It transforms semantic article content at build time and renders it through a small React component map plus scoped CSS.
 
-Scribe is not a hosted blogging platform, CMS, website builder, rich-text editor, proprietary content format, collaboration service, or replacement for React, Next.js, MDX, routing, deployment, analytics, or content storage. The public alpha is tested against React 19.2.7, Next.js 16.2.10, Vite 8.1.3, and MDX 3.1.1. Broader compatibility will be validated through real integrations.
+Scribe is not a hosted blogging platform, CMS, website builder, rich-text editor, proprietary content format, collaboration service, or replacement for React, Next.js, MDX, routing, deployment, analytics, or content storage. The public alpha is tested against React 19.2.7, Next.js 16.2.11, Vite 8.1.3, and MDX 3.1.1. Broader compatibility will be validated through real integrations.
 
 ## Packages
 
@@ -117,10 +117,10 @@ Initialization is minimal and idempotent. It does not replace existing remark/re
 
 ## Next.js MDX integration
 
-The tested Next.js path uses Next 16.2.10 and React 19.2.7. Install Next’s MDX integration if the host does not already have it:
+The tested Next.js path uses Next 16.2.11 and React 19.2.7. Install Next’s MDX integration if the host does not already have it:
 
 ```bash
-bun add @next/mdx@16.2.10 @mdx-js/loader@3.1.1 @mdx-js/react@3.1.1
+bun add @next/mdx@16.2.11 @mdx-js/loader@3.1.1 @mdx-js/react@3.1.1
 ```
 
 Configure the shared Scribe compiler in `next.config.mjs`:
@@ -460,7 +460,7 @@ Scribe owns publication structure, semantic component mappings, responsive artic
 
 The current public-alpha matrix uses fresh packed tarballs for installation, strict typechecking, and production-build claims:
 
-- Framework integrations: React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.10, `@next/mdx` 16.2.10, and `next-mdx-remote` 6.0.0.
+- Framework integrations: React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.11, `@next/mdx` 16.2.11, and `next-mdx-remote` 6.0.0.
 - Declarations: TypeScript 7.0.2 and 6.0.2 with `skipLibCheck: false`.
 - Package and CLI portability: Linux, Windows, and macOS using Bun 1.3.13 and an npm-compatible install flow.
 - Browser behavior: current Playwright-managed Chromium and Firefox, including console errors, uncaught page errors, host isolation, and narrow-viewport overflow.

--- a/playwright.studio.config.ts
+++ b/playwright.studio.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from "@playwright/test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 export default defineConfig({
   testDir: "./tests/studio-browser",
@@ -20,6 +22,9 @@ export default defineConfig({
     cwd: ".",
     url: "http://127.0.0.1:4319",
     reuseExistingServer: false,
-    timeout: 30_000
+    timeout: 30_000,
+    env: {
+      SCRIBE_STUDIO_STATE_DIR: join(tmpdir(), `scribe-studio-playwright-${process.pid}`)
+    }
   }
 });

--- a/scripts/audit-public-packages.mjs
+++ b/scripts/audit-public-packages.mjs
@@ -1,0 +1,22 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const root = join(import.meta.dirname, "..");
+const publicPackages = ["styles", "react", "mdx", "cli"];
+
+for (const directory of publicPackages) {
+  const label = `@scribe-sdk/${directory}`;
+  process.stdout.write(`Auditing ${label} production dependencies...\n`);
+  const result = spawnSync("bun", ["audit", "--production"], {
+    cwd: join(root, "packages", directory),
+    stdio: "inherit"
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    process.stderr.write(`${label} production dependency audit failed.\n`);
+    process.exit(result.status ?? 1);
+  }
+}
+
+process.stdout.write("All public Scribe package production dependency audits passed.\n");

--- a/scripts/test-packed-consumers.mjs
+++ b/scripts/test-packed-consumers.mjs
@@ -144,12 +144,12 @@ async function createNextConsumer() {
     dependencies: {
       "@mdx-js/loader": "3.1.1",
       "@mdx-js/react": "3.1.1",
-      "@next/mdx": "16.2.10",
+      "@next/mdx": "16.2.11",
       "@scribe-sdk/cli": `file:${tarballs.cli}`,
       "@scribe-sdk/mdx": `file:${tarballs.mdx}`,
       "@scribe-sdk/react": `file:${tarballs.react}`,
       "@scribe-sdk/styles": `file:${tarballs.styles}`,
-      next: "16.2.10",
+      next: "16.2.11",
       react: "19.2.7",
       "react-dom": "19.2.7"
     },
@@ -219,7 +219,7 @@ async function createNextRemoteConsumer() {
       "@scribe-sdk/mdx": `file:${tarballs.mdx}`,
       "@scribe-sdk/react": `file:${tarballs.react}`,
       "@scribe-sdk/styles": `file:${tarballs.styles}`,
-      next: "16.2.10",
+      next: "16.2.11",
       "next-mdx-remote": "6.0.0",
       react: "19.2.7",
       "react-dom": "19.2.7"
@@ -276,12 +276,12 @@ async function createNextCssModulesConsumer() {
     dependencies: {
       "@mdx-js/loader": "3.1.1",
       "@mdx-js/react": "3.1.1",
-      "@next/mdx": "16.2.10",
+      "@next/mdx": "16.2.11",
       "@scribe-sdk/cli": `file:${tarballs.cli}`,
       "@scribe-sdk/mdx": `file:${tarballs.mdx}`,
       "@scribe-sdk/react": `file:${tarballs.react}`,
       "@scribe-sdk/styles": `file:${tarballs.styles}`,
-      next: "16.2.10",
+      next: "16.2.11",
       react: "19.2.7",
       "react-dom": "19.2.7"
     },

--- a/tests/integration/next-css-modules/package.json
+++ b/tests/integration/next-css-modules/package.json
@@ -9,11 +9,11 @@
   "dependencies": {
     "@mdx-js/loader": "3.1.1",
     "@mdx-js/react": "3.1.1",
-    "@next/mdx": "16.2.10",
+    "@next/mdx": "16.2.11",
     "@scribe-sdk/mdx": "workspace:*",
     "@scribe-sdk/react": "workspace:*",
     "@scribe-sdk/styles": "workspace:*",
-    "next": "16.2.10",
+    "next": "16.2.11",
     "react": "19.2.7",
     "react-dom": "19.2.7"
   },

--- a/tests/integration/next-remote/package.json
+++ b/tests/integration/next-remote/package.json
@@ -9,7 +9,7 @@
     "@scribe-sdk/mdx": "workspace:*",
     "@scribe-sdk/react": "workspace:*",
     "@scribe-sdk/styles": "workspace:*",
-    "next": "16.2.10",
+    "next": "16.2.11",
     "next-mdx-remote": "6.0.0",
     "react": "19.2.7",
     "react-dom": "19.2.7"

--- a/tests/integration/next/package.json
+++ b/tests/integration/next/package.json
@@ -8,11 +8,11 @@
   "dependencies": {
     "@mdx-js/loader": "3.1.1",
     "@mdx-js/react": "3.1.1",
-    "@next/mdx": "16.2.10",
+    "@next/mdx": "16.2.11",
     "@scribe-sdk/mdx": "workspace:*",
     "@scribe-sdk/react": "workspace:*",
     "@scribe-sdk/styles": "workspace:*",
-    "next": "16.2.10",
+    "next": "16.2.11",
     "react": "19.2.7",
     "react-dom": "19.2.7"
   },

--- a/tests/release/ci.test.ts
+++ b/tests/release/ci.test.ts
@@ -52,6 +52,18 @@ describe("public CI contract", () => {
     }
   });
 
+  it("audits every publishable package without treating private framework fixtures as shipped runtime dependencies", async () => {
+    const workflow = await text(".github/workflows/ci.yml");
+    const manifest = JSON.parse(await text("package.json"));
+    const auditScript = await text("scripts/audit-public-packages.mjs");
+
+    expect(manifest.scripts["release:audit"]).toBe("node scripts/audit-public-packages.mjs");
+    expect(workflow).toContain("run: bun run release:audit");
+    expect(workflow).not.toContain("run: bun audit --production");
+    expect(auditScript).toContain('const publicPackages = ["styles", "react", "mdx", "cli"];');
+    expect(auditScript).toContain('join(root, "packages", directory)');
+  });
+
   it("exposes separate portable browser and canonical Helium commands", async () => {
     const manifest = JSON.parse(await text("package.json"));
 

--- a/tests/release/documentation.test.ts
+++ b/tests/release/documentation.test.ts
@@ -13,7 +13,7 @@ describe("release documentation", () => {
     expect(readme).toContain("Scribe is an open-source publishing SDK that turns ordinary Markdown, MDX, semantic HTML, and JSX into beautiful technical articles on websites you already own.");
     expect(readme).toContain("Just write. Scribe handles the rest.");
     expect(readme).toContain("developers who already own a React website built with Next.js or Vite");
-    expect(readme).toContain("The public alpha is tested against React 19.2.7, Next.js 16.2.10, Vite 8.1.3, and MDX 3.1.1.");
+    expect(readme).toContain("The public alpha is tested against React 19.2.7, Next.js 16.2.11, Vite 8.1.3, and MDX 3.1.1.");
     expect(readme).not.toContain("beta");
     expect(readme).toContain("bun add @scribe-sdk/react@alpha @scribe-sdk/styles@alpha @scribe-sdk/mdx@alpha");
     expect(readme).toContain("bun add --global @scribe-sdk/cli@alpha");
@@ -37,7 +37,7 @@ describe("release documentation", () => {
     const readme = await readFile(join(root, "README.md"), "utf8");
 
     expect(readme).toContain("## Verified compatibility");
-    expect(readme).toContain("React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.10, `@next/mdx` 16.2.10, and `next-mdx-remote` 6.0.0");
+    expect(readme).toContain("React 19.2.7, MDX 3.1.1, Vite 8.1.3, `@vitejs/plugin-react` 6.0.3, Next.js 16.2.11, `@next/mdx` 16.2.11, and `next-mdx-remote` 6.0.0");
     expect(readme).toContain("TypeScript 7.0.2 and 6.0.2 with `skipLibCheck: false`");
     expect(readme).toContain("Linux, Windows, and macOS using Bun 1.3.13 and an npm-compatible install flow");
     expect(readme).toContain("Playwright-managed Chromium and Firefox");

--- a/tests/studio-browser/studio.spec.ts
+++ b/tests/studio-browser/studio.spec.ts
@@ -70,6 +70,33 @@ test("keeps Markdown canonical while constrained Rich Text edits update the mirr
   await expect(page.getByRole("toolbar", { name: "Markdown formatting" })).toHaveCount(0);
   await page.screenshot({ path: testInfo.outputPath("studio-markdown.png"), fullPage: true });
 
+  const diskSource = await source.inputValue();
+  await source.fill("# Browser recovery draft\n");
+  const serverBeforeDebounce = await page.evaluate(async () => (await fetch("/__scribe/api/document")).json());
+  expect(serverBeforeDebounce.source).toBe(diskSource);
+  await expect.poll(() => page.evaluate(async (recoveryKey) => {
+    const database = await new Promise<IDBDatabase>((resolveDatabase, reject) => {
+      const opening = indexedDB.open("scribe-studio-recovery", 1);
+      opening.onsuccess = () => resolveDatabase(opening.result);
+      opening.onerror = () => reject(opening.error);
+    });
+    try {
+      return await new Promise<string | undefined>((resolveDraft, reject) => {
+        const request = database.transaction("drafts", "readonly").objectStore("drafts").get(recoveryKey);
+        request.onsuccess = () => resolveDraft(request.result?.source);
+        request.onerror = () => reject(request.error);
+      });
+    } finally {
+      database.close();
+    }
+  }, serverBeforeDebounce.recoveryKey)).toBe("# Browser recovery draft\n");
+  await page.reload();
+  await expect(source).toHaveValue("# Browser recovery draft\n");
+  await expect(page.locator("#status-text")).not.toHaveText("Read-only tab");
+
+  await preview.locator("body").evaluate(() => {
+    (window as typeof window & { __scribeHmrProof?: string }).__scribeHmrProof = "preserved";
+  });
   await source.fill("# Live studio draft\n\nThe preview uses the production Scribe renderer.\n\n<Callout variant=\"note\">Protected note.</Callout>\n");
   await expect(page.locator("#status-text")).toHaveText("Unsaved draft");
   await expect(page.locator(".save-contract")).toContainText("Draft only — Save writes to");
@@ -79,6 +106,7 @@ test("keeps Markdown canonical while constrained Rich Text edits update the mirr
     return event.defaultPrevented;
   })).toBe(true);
   await expect(preview.locator("h1#live-studio-draft")).toBeVisible();
+  expect(await preview.locator("body").evaluate(() => (window as typeof window & { __scribeHmrProof?: string }).__scribeHmrProof)).toBe("preserved");
 
   await source.fill("<Callout>unfinished");
   await expect(page.locator("#status-text")).toHaveText("Compilation blocked");


### PR DESCRIPTION
## Linear

Refs AET-15

## Summary

- durably journal acknowledged drafts and immediately preserve unsent browser and Rich Text edits in IndexedDB
- serialize revisioned mutations behind a single-writer lease and reject stale, cross-origin, or conflicting writes
- save through conflict-aware, symlink-safe atomic replacement while preserving UTF-8 BOMs, line endings, and file permissions
- isolate MDX compilation in a restartable worker and replace polling/full preview reloads with SSE and Vite HMR
- cover recovery, corruption, worker failure, external edits, deletion, symlink swaps, multi-tab behavior, and preview continuity

## Verification

- [x] Focused tests pass — 54 Studio tests
- [x] Type checking passes
- [x] Meaningful consumer-facing changes include a Changeset
- [x] No documentation change is required; behavior is internal hardening with existing user-facing recovery diagnostics
- [x] Existing coverage was not weakened or skipped
- [x] CLI production build passes
- [x] Focused Chromium Studio flow passes
- [x] `git diff --check` passes

## Visual evidence

No intentional visual change. The focused Chromium Studio flow verifies that draft updates reach the production preview through HMR without replacing the iframe document.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable draft recovery across browser and application restarts.
  * Added writer coordination so concurrent edits are serialized and stale changes are detected.
  * Added safer saving that preserves symlinks, permissions, BOMs, and line endings while preventing overwrites after external edits.
  * Improved live preview updates without unnecessarily reloading the preview document.
  * Added clearer read-only, reconnecting, conflict, and unsaved-change states.
  * Added background MDX validation with resilient error handling.

* **Bug Fixes**
  * Improved protection against invalid, corrupted, cross-origin, and conflicting Studio mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->