### PR TITLE
fix: make alpha publishing fail closed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
       - name: Install an OIDC-capable npm CLI
-        run: npm install --global npm@12.0.2
+        run: npm install --global npm@11.6.2
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Verify release alignment

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -79,7 +79,7 @@ Do not repeat it for each alpha. Add normal Changeset fragments during the cycle
 The `Release` GitHub Actions workflow runs only after the complete `CI` workflow succeeds for a push to `main`. It never runs for pull requests, failed CI, cancelled CI, or manually dispatched CI. The workflow has two deterministic outcomes:
 
 1. When unreleased Changeset fragments exist, it creates or updates the ready `changeset-release/main` version pull request, synchronizes package versions and changelogs, refreshes `bun.lock`, and dispatches CI for that exact release branch.
-2. When a verified version pull request has been merged and no unreleased fragments remain, it rebuilds and inspects the packages, then publishes the unpublished synchronized versions. Alpha prerelease mode makes Changesets publish under `alpha`; the workflow never targets `latest`, creates Git tags, or creates GitHub releases.
+2. When a verified version pull request has been merged and no unreleased fragments remain, it rebuilds and inspects the packages, then runs Scribe's guarded publisher. The publisher requires alpha prerelease mode, publishes each inspected tarball with an explicit `--tag alpha`, skips versions already on npm, publishes the CLI last, and fails if `latest` moves.
 
 Publishing uses npm trusted publishing through GitHub OIDC. No npm write token, OTP, or `NODE_AUTH_TOKEN` belongs in GitHub secrets.
 
@@ -93,7 +93,7 @@ Before the first automated publication, complete these one-time owner settings:
    - workflow filename: `release.yml`
    - environment: blank
    - allowed action: `npm publish`
-3. Do not add an npm automation token. The workflow uses Node 24, npm 12.0.2, a GitHub-hosted runner, and `id-token: write` so npm can exchange the job identity for a short-lived publishing credential.
+3. Do not add an npm automation token. The workflow uses Node 24, npm 11.6.2, a GitHub-hosted runner, and `id-token: write` so npm can exchange the job identity for a short-lived publishing credential.
 
 The workflow intentionally creates no Git tag or GitHub release. Those remain explicit owner decisions after registry verification.
 
@@ -184,15 +184,15 @@ After versioning, run every gate from the repository root:
 
 Before publication, confirm `npm whoami` reports the intended account and that it may publish public packages in the `@scribe-sdk` scope. Keep credentials and one-time passwords outside the repository.
 
-While prerelease mode is active, the installed Changesets CLI reads the `alpha` dist-tag from `.changeset/pre.json` and rejects a custom `--tag` argument. After all gates pass, the automated workflow publishes the synchronized packages with:
+Changesets owns versioning and changelogs; it does not publish Scribe packages. After all gates pass, the automated workflow publishes the inspected tarballs with:
 
 ```bash
-bunx changeset publish --no-git-tag
+bun run release:packages
 ```
 
-The root equivalent is `bun run release:packages`. Changesets reads the `alpha` dist-tag from `.changeset/pre.json`; `--no-git-tag` preserves the current policy that package publication does not automatically create Git tags. Changesets discovers unpublished workspace versions and handles the internal `@scribe-sdk/mdx` dependency used by `@scribe-sdk/cli`. npm authenticates this command from the workflow's OIDC identity. Verify the resulting dist-tags immediately and do not proceed to tagging if `latest` changes.
+The publisher verifies `.changeset/pre.json`, synchronized `0.1.0-alpha.N` manifests, and the npm dist-tags. It publishes only missing `.scribe-release/*.tgz` artifacts, explicitly passes `npm publish --tag alpha --access public`, and protects the `latest` dist-tag by comparing it before and after publication. npm authenticates the command from the workflow's OIDC identity.
 
-Do not execute this command manually during ordinary release preparation. Manual publication remains an emergency fallback after diagnosing a failed automated release.
+Do not execute this command manually during ordinary release preparation. Manual publication remains an emergency fallback after diagnosing a failed automated release. Run it from an interactive terminal so npm can open its browser/passkey challenge; never paste a credential into the repository or CI logs. Publish tarballs in the documented order—styles, React, MDX, then CLI—and always include `--tag alpha --access public`.
 
 ## Post-publication smoke tests
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "release:consumers": "node scripts/test-packed-consumers.mjs",
     "release:pack": "node scripts/pack-packages.mjs",
     "release:pack:dry": "node scripts/pack-packages.mjs --dry-run",
-    "release:packages": "changeset publish --no-git-tag",
+    "release:packages": "node scripts/publish-alpha-packages.mjs",
     "release:visual": "node scripts/run-helium-visual.mjs --require-helium",
     "portability:check": "node scripts/check-portability.mjs",
     "test": "vitest run",

--- a/scripts/publish-alpha-packages.d.mts
+++ b/scripts/publish-alpha-packages.d.mts
@@ -1,0 +1,19 @@
+export interface PublicPackage {
+  readonly name: "@scribe-sdk/styles" | "@scribe-sdk/react" | "@scribe-sdk/mdx" | "@scribe-sdk/cli";
+  readonly directory: "styles" | "react" | "mdx" | "cli";
+}
+
+export interface PackageRegistry {
+  versions(name: PublicPackage["name"]): Promise<string[]>;
+  distTags(name: PublicPackage["name"]): Promise<Record<string, string | undefined>>;
+  publishTarball(name: PublicPackage["name"], tarball: string, tag: "alpha"): Promise<void>;
+}
+
+export const publicPackages: readonly PublicPackage[];
+
+export function isDirectExecution(moduleUrl: string, entryPath: string | undefined, cwd?: string): boolean;
+
+export function publishAlphaPackages(options?: {
+  root?: string;
+  registry?: PackageRegistry;
+}): Promise<void>;

--- a/scripts/publish-alpha-packages.mjs
+++ b/scripts/publish-alpha-packages.mjs
@@ -1,0 +1,111 @@
+import { access, readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { spawnPortableSync } from "./lib/spawn.mjs";
+
+export const publicPackages = [
+  { name: "@scribe-sdk/styles", directory: "styles" },
+  { name: "@scribe-sdk/react", directory: "react" },
+  { name: "@scribe-sdk/mdx", directory: "mdx" },
+  { name: "@scribe-sdk/cli", directory: "cli" }
+];
+
+const defaultRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+export async function publishAlphaPackages({ root = defaultRoot, registry = npmRegistry } = {}) {
+  const pre = await readJson(join(root, ".changeset", "pre.json"));
+  assert(
+    pre.mode === "pre" && pre.tag === "alpha",
+    "Package publication requires Changesets alpha prerelease mode."
+  );
+
+  const releases = await Promise.all(publicPackages.map(async ({ name, directory }) => {
+    const manifest = await readJson(join(root, "packages", directory, "package.json"));
+    assert(manifest.name === name, `Expected ${name} in packages/${directory}/package.json.`);
+    assert(
+      /^\d+\.\d+\.\d+-alpha\.\d+$/u.test(manifest.version),
+      `${name}@${String(manifest.version)} is not an alpha prerelease.`
+    );
+    return {
+      name,
+      version: manifest.version,
+      tarball: join(root, ".scribe-release", `scribe-sdk-${directory}-${manifest.version}.tgz`)
+    };
+  }));
+
+  const versions = new Set(releases.map(({ version }) => version));
+  assert(versions.size === 1, `Public package versions are not synchronized: ${[...versions].join(", ")}.`);
+  const [version] = versions;
+  const tagsBefore = new Map();
+
+  for (const { name } of releases) tagsBefore.set(name, await registry.distTags(name));
+
+  for (const release of releases) {
+    const publishedVersions = await registry.versions(release.name);
+    if (publishedVersions.includes(release.version)) {
+      process.stdout.write(`Skipping ${release.name}@${release.version}; it is already published.\n`);
+      continue;
+    }
+
+    await access(release.tarball);
+    process.stdout.write(`Publishing ${release.name}@${release.version} with the alpha dist-tag.\n`);
+    await registry.publishTarball(release.name, release.tarball, "alpha");
+  }
+
+  for (const { name } of releases) {
+    const tagsAfter = await registry.distTags(name);
+    const latestBefore = tagsBefore.get(name)?.latest;
+    assert(
+      tagsAfter.latest === latestBefore,
+      `${name} changed latest from ${String(latestBefore)} to ${String(tagsAfter.latest)}.`
+    );
+    assert(tagsAfter.alpha === version, `${name} has alpha=${String(tagsAfter.alpha)}; expected ${version}.`);
+  }
+
+  process.stdout.write(`Verified all public packages at alpha=${version}; latest was unchanged.\n`);
+}
+
+const npmRegistry = {
+  async versions(name) {
+    const value = runNpmJson(["view", name, "versions", "--json"]);
+    return Array.isArray(value) ? value : [value];
+  },
+  async distTags(name) {
+    return runNpmJson(["view", name, "dist-tags", "--json"]);
+  },
+  async publishTarball(_name, tarball, tag) {
+    runNpm(["publish", tarball, "--tag", tag, "--access", "public"], "inherit");
+  }
+};
+
+function runNpmJson(args) {
+  const output = runNpm(args, "pipe");
+  return JSON.parse(output);
+}
+
+function runNpm(args, stdio) {
+  const result = spawnPortableSync("npm", args, {
+    cwd: defaultRoot,
+    encoding: "utf8",
+    stdio: stdio === "inherit" ? "inherit" : ["ignore", "pipe", "inherit"]
+  });
+  if (result.status !== 0) throw new Error(`npm ${args.join(" ")} exited with code ${String(result.status)}.`);
+  return result.stdout ?? "";
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+export function isDirectExecution(moduleUrl, entryPath, cwd = process.cwd()) {
+  return Boolean(entryPath) && fileURLToPath(moduleUrl) === resolve(cwd, entryPath);
+}
+
+if (isDirectExecution(import.meta.url, process.argv[1])) {
+  await publishAlphaPackages();
+}

--- a/tests/release/changesets.test.ts
+++ b/tests/release/changesets.test.ts
@@ -97,7 +97,7 @@ describe("Changesets release policy", () => {
       changeset: "changeset",
       "changeset:status": "changeset status",
       "version:packages": "node scripts/version-packages.mjs",
-      "release:packages": "changeset publish --no-git-tag",
+      "release:packages": "node scripts/publish-alpha-packages.mjs",
       "release:check": "node scripts/check-release-alignment.mjs"
     });
     const versionScript = await readFile(join(root, "scripts", "version-packages.mjs"), "utf8");
@@ -116,8 +116,9 @@ describe("Changesets release policy", () => {
     expect(releasing).toContain("bunx changeset status");
     expect(releasing).toContain("bunx changeset pre enter alpha");
     expect(releasing).toContain("bunx changeset version");
-    expect(releasing).toContain("bunx changeset publish --no-git-tag");
-    expect(releasing).not.toContain("changeset publish --tag alpha");
+    expect(releasing).toContain("bun run release:packages");
+    expect(releasing).toContain("npm publish");
+    expect(releasing).toContain("--tag alpha");
     expect(releasing).toContain("bunx changeset pre exit");
     expect(releasing).toContain("observable user impact");
     expect(releasing).toContain("packages/*/CHANGELOG.md");

--- a/tests/release/ci.test.ts
+++ b/tests/release/ci.test.ts
@@ -53,6 +53,7 @@ describe("public CI contract", () => {
     expect(workflow).toContain("cancel-in-progress: false");
     expect(workflow).toMatch(/permissions:\s*\n\s*actions: write\s*\n\s*contents: write\s*\n\s*id-token: write\s*\n\s*pull-requests: write/u);
     expect(workflow).toContain("node-version: \"24\"");
+    expect(workflow).toContain("npm@11.6.2");
     expect(workflow).toContain("package-manager-cache: false");
     expect(workflow).toContain("uses: changesets/action@v1");
     expect(workflow).toContain("version: bun run version:packages");

--- a/tests/release/package-manifests.test.ts
+++ b/tests/release/package-manifests.test.ts
@@ -60,8 +60,8 @@ describe("publishable package manifests", () => {
     const releasing = await readFile(join(root, "RELEASING.md"), "utf8");
 
     await expect(access(join(root, "RELEASE_NOTES.md"))).rejects.toThrow();
-    expect(releasing).toContain("bunx changeset publish --no-git-tag");
-    expect(releasing).toContain("reads the `alpha` dist-tag from `.changeset/pre.json`");
+    expect(releasing).toContain("bun run release:packages");
+    expect(releasing).toContain("protects the `latest` dist-tag");
     expect(releasing).toContain("Post-publication smoke tests");
     expect(releasing).toContain("npm view @scribe-sdk/react dist-tags");
     expect(releasing).not.toMatch(/\/home\/|\\Users\\|_authToken|npm_[A-Za-z0-9]{20,}|gh[pousr]_[A-Za-z0-9]{20,}/u);

--- a/tests/release/publish-packages.test.ts
+++ b/tests/release/publish-packages.test.ts
@@ -1,0 +1,119 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  isDirectExecution,
+  publicPackages,
+  publishAlphaPackages
+} from "../../scripts/publish-alpha-packages.mjs";
+
+describe("alpha package publisher", () => {
+  it("recognizes the relative script path used by the root package command", () => {
+    expect(isDirectExecution(
+      "file:///workspace/scripts/publish-alpha-packages.mjs",
+      "scripts/publish-alpha-packages.mjs",
+      "/workspace"
+    )).toBe(true);
+  });
+
+  it("publishes missing tarballs explicitly to alpha with the CLI last", async () => {
+    const root = await releaseFixture();
+    const versions = new Map(publicPackages.map(({ name }) => [name, ["0.1.0-alpha.7"]]));
+    const tags = new Map(publicPackages.map(({ name }) => [name, { alpha: "0.1.0-alpha.7", latest: "0.1.0-alpha.4" }]));
+    const published: Array<{ name: string; tarball: string; tag: string }> = [];
+
+    await publishAlphaPackages({
+      root,
+      registry: {
+        versions: async (name) => versions.get(name) ?? [],
+        distTags: async (name) => tags.get(name) ?? {},
+        publishTarball: async (name, tarball, tag) => {
+          published.push({ name, tarball, tag });
+          versions.get(name)?.push("0.1.0-alpha.8");
+          tags.set(name, { alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" });
+        }
+      }
+    });
+
+    expect(published.map(({ name }) => name)).toEqual([
+      "@scribe-sdk/styles",
+      "@scribe-sdk/react",
+      "@scribe-sdk/mdx",
+      "@scribe-sdk/cli"
+    ]);
+    expect(published.every(({ tag }) => tag === "alpha")).toBe(true);
+    expect(published.at(-1)?.tarball.endsWith("scribe-sdk-cli-0.1.0-alpha.8.tgz")).toBe(true);
+  });
+
+  it("skips versions that are already published", async () => {
+    const root = await releaseFixture();
+    const publishTarball = async () => {
+      throw new Error("already-published packages must not be republished");
+    };
+
+    await expect(publishAlphaPackages({
+      root,
+      registry: {
+        versions: async () => ["0.1.0-alpha.8"],
+        distTags: async () => ({ alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" }),
+        publishTarball
+      }
+    })).resolves.toBeUndefined();
+  });
+
+  it("fails closed when publication moves latest", async () => {
+    const root = await releaseFixture();
+    let published = false;
+
+    await expect(publishAlphaPackages({
+      root,
+      registry: {
+        versions: async () => published ? ["0.1.0-alpha.8"] : ["0.1.0-alpha.7"],
+        distTags: async () => ({
+          alpha: published ? "0.1.0-alpha.8" : "0.1.0-alpha.7",
+          latest: published ? "0.1.0-alpha.8" : "0.1.0-alpha.4"
+        }),
+        publishTarball: async () => {
+          published = true;
+        }
+      }
+    })).rejects.toThrow("changed latest");
+  });
+
+  it("rejects release state that is not an alpha prerelease", async () => {
+    const root = await releaseFixture({ mode: "exit", tag: "alpha" });
+
+    await expect(publishAlphaPackages({
+      root,
+      registry: {
+        versions: async () => [],
+        distTags: async () => ({}),
+        publishTarball: async () => undefined
+      }
+    })).rejects.toThrow("alpha prerelease mode");
+  });
+});
+
+async function releaseFixture(pre = { mode: "pre", tag: "alpha" }): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "scribe-alpha-publish-"));
+  await mkdir(join(root, ".changeset"), { recursive: true });
+  await mkdir(join(root, ".scribe-release"), { recursive: true });
+  await writeFile(join(root, ".changeset", "pre.json"), JSON.stringify(pre));
+
+  for (const { directory } of publicPackages) {
+    await mkdir(join(root, "packages", directory), { recursive: true });
+    await writeFile(join(root, "packages", directory, "package.json"), JSON.stringify({
+      name: `@scribe-sdk/${directory}`,
+      version: "0.1.0-alpha.8"
+    }));
+    await writeFile(
+      join(root, ".scribe-release", `scribe-sdk-${directory}-0.1.0-alpha.8.tgz`),
+      "fixture"
+    );
+  }
+
+  return root;
+}


### PR DESCRIPTION
## What changed

- replace implicit Changesets publication with a guarded tarball publisher that explicitly uses the `alpha` dist-tag
- skip already-published versions, publish the CLI last, and verify `latest` never moves
- pin npm 11.6.2 to avoid npm 12 rewriting the CLI bin manifest
- correct the release documentation and add behavioral regression coverage

## Root cause

Changesets treats a prerelease with no prior stable version differently from the repository's documented assumption and would target `latest`. The old tests asserted command text instead of exercising tag behavior.

## Verification

- `bun run test` — 252 tests passed
- `bun run typecheck`
- `bun run build`
- `bun run docs:check`
- `bun run release:pack`
- `bun run release:inspect`
- `bun run release:packages` against npm — all packages skipped at `0.1.0-alpha.8`; `alpha` verified and `latest` unchanged
- npm 11.6.2 dry-packed the CLI with both `scribe` and `scb` binaries intact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Improved alpha package publishing with synchronized version checks and explicit `alpha` tagging.
  * Existing published versions are skipped automatically, and the CLI is published after supporting packages.
  * Added safeguards to prevent unintended changes to the `latest` release channel.

* **Documentation**
  * Updated release instructions for the revised alpha publishing workflow and validation steps.

* **Tests**
  * Expanded automated coverage for prerelease validation, package ordering, duplicate handling, and release-channel protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->