### PR TITLE
fix(release): wait for the alpha dist-tag to converge after publishing

### DIFF
--- a/scripts/publish-alpha-packages.d.mts
+++ b/scripts/publish-alpha-packages.d.mts
@@ -16,4 +16,6 @@ export function isDirectExecution(moduleUrl: string, entryPath: string | undefin
 export function publishAlphaPackages(options?: {
   root?: string;
   registry?: PackageRegistry;
+  distTagAttempts?: number;
+  distTagDelayMs?: number;
 }): Promise<void>;

--- a/scripts/publish-alpha-packages.mjs
+++ b/scripts/publish-alpha-packages.mjs
@@ -1,5 +1,6 @@
 import { access, readFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
 import { spawnPortableSync } from "./lib/spawn.mjs";
@@ -13,7 +14,12 @@ export const publicPackages = [
 
 const defaultRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
-export async function publishAlphaPackages({ root = defaultRoot, registry = npmRegistry } = {}) {
+export async function publishAlphaPackages({
+  root = defaultRoot,
+  registry = npmRegistry,
+  distTagAttempts = 12,
+  distTagDelayMs = 500
+} = {}) {
   const pre = await readJson(join(root, ".changeset", "pre.json"));
   assert(
     pre.mode === "pre" && pre.tag === "alpha",
@@ -51,14 +57,10 @@ export async function publishAlphaPackages({ root = defaultRoot, registry = npmR
     await access(release.tarball);
     process.stdout.write(`Publishing ${release.name}@${release.version} with the alpha dist-tag.\n`);
     await registry.publishTarball(release.name, release.tarball, "alpha");
-
-    const tagsAfter = await registry.distTags(release.name);
-    const latestBefore = tagsBefore.get(release.name)?.latest;
-    assert(
-      tagsAfter.latest === latestBefore,
-      `${release.name} changed latest from ${String(latestBefore)} to ${String(tagsAfter.latest)}.`
-    );
-    assert(tagsAfter.alpha === version, `${release.name} has alpha=${String(tagsAfter.alpha)}; expected ${version}.`);
+    await assertPublishedAtAlpha(registry, release.name, version, tagsBefore.get(release.name)?.latest, {
+      attempts: distTagAttempts,
+      delayMs: distTagDelayMs
+    });
   }
 
   process.stdout.write(`Verified all public packages at alpha=${version}; latest was unchanged.\n`);
@@ -76,6 +78,29 @@ const npmRegistry = {
     runNpm(["publish", tarball, "--tag", tag, "--access", "public"], "inherit");
   }
 };
+
+async function assertPublishedAtAlpha(registry, name, expected, latestBefore, { attempts, delayMs }) {
+  const latestOk = (tags) => tags.latest === latestBefore;
+  const alphaOk = (tags) => tags.alpha === expected;
+  let tags = {};
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    tags = await registry.distTags(name);
+    if (latestOk(tags)) {
+      if (alphaOk(tags)) return;
+      process.stdout.write(
+        `Waiting for ${name} dist-tag alpha to converge to ${expected} (attempt ${attempt}/${attempts}).\n`
+      );
+      await sleep(delayMs);
+      continue;
+    }
+    throw new Error(
+      `${name} changed latest from ${String(latestBefore)} to ${String(tags.latest)}.`
+    );
+  }
+
+  throw new Error(`${name} has alpha=${String(tags.alpha)}; expected ${expected}.`);
+}
 
 function runNpmJson(args) {
   const output = runNpm(args, "pipe");

--- a/scripts/publish-alpha-packages.mjs
+++ b/scripts/publish-alpha-packages.mjs
@@ -20,6 +20,15 @@ export async function publishAlphaPackages({
   distTagAttempts = 12,
   distTagDelayMs = 500
 } = {}) {
+  assert(
+    Number.isInteger(distTagAttempts) && distTagAttempts > 0,
+    `distTagAttempts must be a positive integer; received ${String(distTagAttempts)}.`
+  );
+  assert(
+    Number.isFinite(distTagDelayMs) && distTagDelayMs >= 0,
+    `distTagDelayMs must be finite and non-negative; received ${String(distTagDelayMs)}.`
+  );
+
   const pre = await readJson(join(root, ".changeset", "pre.json"));
   assert(
     pre.mode === "pre" && pre.tag === "alpha",
@@ -88,10 +97,12 @@ async function assertPublishedAtAlpha(registry, name, expected, latestBefore, { 
     tags = await registry.distTags(name);
     if (latestOk(tags)) {
       if (alphaOk(tags)) return;
-      process.stdout.write(
-        `Waiting for ${name} dist-tag alpha to converge to ${expected} (attempt ${attempt}/${attempts}).\n`
-      );
-      await sleep(delayMs);
+      if (attempt < attempts) {
+        process.stdout.write(
+          `Waiting for ${name} dist-tag alpha to converge to ${expected} (attempt ${attempt}/${attempts}).\n`
+        );
+        await sleep(delayMs);
+      }
       continue;
     }
     throw new Error(

--- a/tests/release/publish-packages.test.ts
+++ b/tests/release/publish-packages.test.ts
@@ -64,6 +64,63 @@ describe("alpha package publisher", () => {
     })).resolves.toBeUndefined();
   });
 
+  it("waits for the alpha dist-tag to converge after publishing", async () => {
+    const root = await releaseFixture();
+    const versions = new Map(publicPackages.map(({ name }) => [name, ["0.1.0-alpha.7"]]));
+    const tags = new Map(publicPackages.map(({ name }) => [name, { alpha: "0.1.0-alpha.7", latest: "0.1.0-alpha.4" }]));
+    const published: Array<{ name: string }> = [];
+    const postPublishReads = new Map(publicPackages.map(({ name }) => [name, 0]));
+
+    await publishAlphaPackages({
+      root,
+      distTagAttempts: 3,
+      distTagDelayMs: 0,
+      registry: {
+        versions: async (name) => versions.get(name) ?? [],
+        distTags: async (name) => {
+          const tag = tags.get(name) ?? {};
+          const isPublished = published.some((entry) => entry.name === name);
+          if (isPublished) {
+            const n = (postPublishReads.get(name) ?? 0) + 1;
+            postPublishReads.set(name, n);
+            if (n < 2) return { ...tag, alpha: "0.1.0-alpha.7" };
+          }
+          return tag;
+        },
+        publishTarball: async (name) => {
+          published.push({ name });
+          versions.get(name)?.push("0.1.0-alpha.8");
+          tags.set(name, { alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" });
+        }
+      }
+    });
+    expect(postPublishReads.get("@scribe-sdk/styles")).toBeGreaterThanOrEqual(2);
+    expect(published.map(({ name }) => name)).toEqual([
+      "@scribe-sdk/styles",
+      "@scribe-sdk/react",
+      "@scribe-sdk/mdx",
+      "@scribe-sdk/cli"
+    ]);
+  });
+
+  it("fails closed when the alpha dist-tag never converges", async () => {
+    const root = await releaseFixture();
+    const published: string[] = [];
+
+    await expect(publishAlphaPackages({
+      root,
+      distTagAttempts: 3,
+      distTagDelayMs: 0,
+      registry: {
+        versions: async (name) => published.includes(name) ? ["0.1.0-alpha.8"] : [],
+        distTags: async () => ({ alpha: "0.1.0-alpha.7", latest: "0.1.0-alpha.4" }),
+        publishTarball: async (name) => {
+          published.push(name);
+        }
+      }
+    })).rejects.toThrow("has alpha=0.1.0-alpha.7; expected 0.1.0-alpha.8");
+  });
+
   it("fails closed when publication moves latest", async () => {
     const root = await releaseFixture();
     let published = false;


### PR DESCRIPTION
npm read replicas lag the registry write, so verifying dist-tags immediately after `npm publish` read the previous alpha version and the guarded publisher aborted before react, mdx, and cli were published (leaving them at alpha.8 while styles reached alpha.9).

- Publish each inspected tarball first, then poll the `alpha` dist-tag with bounded backoff until it converges.
- Keep the `latest`-tag guard as a hard assert; fail closed before later packages if `latest` ever moves.
- Make `distTagAttempts`/`distTagDelayMs` injectable so tests stay fast and deterministic.
- Add regression tests: convergence retry and fail-closed on non-convergence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alpha package publishing reliability by retrying verification until the expected `alpha` tag is available.
  * Ensured the `latest` tag remains unchanged during alpha publishing.
  * Publishing now reports a failure if the expected tag does not converge.

* **New Features**
  * Added configurable retry attempts and delay for alpha tag verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->