### PR TITLE
fix(release): point latest dist-tag at the newest published version

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -192,7 +192,7 @@ bun run release:packages
 
 The publisher verifies `.changeset/pre.json`, synchronized `0.1.0-alpha.N` manifests, and the npm dist-tags. It publishes only missing `.scribe-release/*.tgz` artifacts, explicitly passes `npm publish --tag alpha --access public`, waits for the `alpha` dist-tag to converge, then repoints `latest` at the published version and waits for that to converge too. npm authenticates the commands from the workflow's OIDC identity.
 
-Do not execute this command manually during ordinary release preparation. Manual publication remains an emergency fallback after diagnosing a failed automated release. Run it from an interactive terminal so npm can open its browser/passkey challenge; never paste a credential into the repository or CI logs. Publish tarballs in the documented order—styles, React, MDX, then CLI—and always include `--tag alpha --access public`.
+Do not execute this command manually during ordinary release preparation. Manual publication remains an emergency fallback after diagnosing a failed automated release. Run it from an interactive terminal so npm can open its browser/passkey challenge; never paste a credential into the repository or CI logs. Publish tarballs in the documented order—styles, React, MDX, then CLI—and always include `--tag alpha --access public`. For each package, verify the `alpha` dist-tag resolves to the published version, then explicitly repoint `latest` with `npm dist-tag add @scribe-sdk/<name>@<version> latest` and verify `latest` resolves to that version before continuing, matching the publisher's convergence checks.
 
 ## Post-publication smoke tests
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -72,14 +72,14 @@ The one-time command used to enter this cycle is:
 bunx changeset pre enter alpha
 ```
 
-Do not repeat it for each alpha. Add normal Changeset fragments during the cycle. `bunx changeset version` consumes new fragments and advances all fixed packages to the next `0.1.0-alpha.N` version. The prerelease tag and intended npm dist-tag are both `alpha`; never publish an alpha to `latest`.
+Do not repeat it for each alpha. Add normal Changeset fragments during the cycle. `bunx changeset version` consumes new fragments and advances all fixed packages to the next `0.1.0-alpha.N` version. The prerelease tag for new versions is `alpha`, and `latest` is repointed at the newest published alpha after each publication so the public package pages and tagless installs reflect the current build.
 
 ## Automated release path
 
 The `Release` GitHub Actions workflow runs only after the complete `CI` workflow succeeds for a push to `main`. It never runs for pull requests, failed CI, cancelled CI, or manually dispatched CI. The workflow has two deterministic outcomes:
 
 1. When unreleased Changeset fragments exist, it creates or updates the ready `changeset-release/main` version pull request, synchronizes package versions and changelogs, refreshes `bun.lock`, and dispatches CI for that exact release branch.
-2. When a verified version pull request has been merged and no unreleased fragments remain, it rebuilds and inspects the packages, then runs Scribe's guarded publisher. The publisher requires alpha prerelease mode, publishes each inspected tarball with an explicit `--tag alpha`, skips versions already on npm, publishes the CLI last, and fails if `latest` moves.
+2. When a verified version pull request has been merged and no unreleased fragments remain, it rebuilds and inspects the packages, then runs Scribe's guarded publisher. The publisher requires alpha prerelease mode, publishes each inspected tarball with an explicit `--tag alpha`, skips versions already on npm, publishes the CLI last, waits for each dist-tag to converge, and points `latest` at the newest published version.
 
 Publishing uses npm trusted publishing through GitHub OIDC. No npm write token, OTP, or `NODE_AUTH_TOKEN` belongs in GitHub secrets.
 
@@ -190,7 +190,7 @@ Changesets owns versioning and changelogs; it does not publish Scribe packages. 
 bun run release:packages
 ```
 
-The publisher verifies `.changeset/pre.json`, synchronized `0.1.0-alpha.N` manifests, and the npm dist-tags. It publishes only missing `.scribe-release/*.tgz` artifacts, explicitly passes `npm publish --tag alpha --access public`, and protects the `latest` dist-tag by comparing it before and after publication. npm authenticates the command from the workflow's OIDC identity.
+The publisher verifies `.changeset/pre.json`, synchronized `0.1.0-alpha.N` manifests, and the npm dist-tags. It publishes only missing `.scribe-release/*.tgz` artifacts, explicitly passes `npm publish --tag alpha --access public`, waits for the `alpha` dist-tag to converge, then repoints `latest` at the published version and waits for that to converge too. npm authenticates the commands from the workflow's OIDC identity.
 
 Do not execute this command manually during ordinary release preparation. Manual publication remains an emergency fallback after diagnosing a failed automated release. Run it from an interactive terminal so npm can open its browser/passkey challenge; never paste a credential into the repository or CI logs. Publish tarballs in the documented order—styles, React, MDX, then CLI—and always include `--tag alpha --access public`.
 
@@ -230,4 +230,4 @@ bunx changeset pre exit
 bunx changeset version
 ```
 
-Review the stable versions and generated changelogs, refresh the lockfile, and rerun every verification gate. Publish stable packages only after a separate owner review; omit `--tag alpha` so the deliberate stable release can become `latest`.
+Review the stable versions and generated changelogs, refresh the lockfile, and rerun every verification gate. Publish stable packages only after a separate owner review; publish without `--tag alpha` and repoint `latest` so the deliberate stable release replaces the newest alpha as `latest`.

--- a/docs/superpowers/plans/2026-08-01-medium-import-alpha-release.md
+++ b/docs/superpowers/plans/2026-08-01-medium-import-alpha-release.md
@@ -11,7 +11,7 @@
 ## Global Constraints
 
 - All four public packages remain synchronized in the `0.1.0-alpha.N` fixed group.
-- Publication uses the `alpha` dist-tag and never changes `latest`.
+- Publication uses the `alpha` dist-tag and repoints `latest` at the newest published version.
 - The packed CLI must expose `scribe import` and import a Medium ZIP in a fresh consumer.
 - Root workspace overrides must not hide the dependency graph received by npm consumers.
 - Windows, Linux, macOS, Chromium, Firefox, and the Linux release gates must pass before merge.
@@ -115,4 +115,4 @@ Wait for the automated `changeset-release/main` PR, confirm synchronized `0.1.0-
 
 - [ ] **Step 5: Verify registry publication**
 
-Confirm all four npm `alpha` tags resolve to the same new version while `latest` remains unchanged. Install the registry packages in a fresh consumer and run `scribe --version`, `scribe import --help`, a Medium ZIP import, and article validation.
+Confirm all four npm `alpha` tags resolve to the same new version and `latest` is repointed at that version. Install the registry packages in a fresh consumer and run `scribe --version`, `scribe import --help`, a Medium ZIP import, and article validation.

--- a/scripts/publish-alpha-packages.d.mts
+++ b/scripts/publish-alpha-packages.d.mts
@@ -7,6 +7,7 @@ export interface PackageRegistry {
   versions(name: PublicPackage["name"]): Promise<string[]>;
   distTags(name: PublicPackage["name"]): Promise<Record<string, string | undefined>>;
   publishTarball(name: PublicPackage["name"], tarball: string, tag: "alpha"): Promise<void>;
+  setDistTag(name: PublicPackage["name"], version: string, tag: "latest"): Promise<void>;
 }
 
 export const publicPackages: readonly PublicPackage[];

--- a/scripts/publish-alpha-packages.mjs
+++ b/scripts/publish-alpha-packages.mjs
@@ -52,27 +52,26 @@ export async function publishAlphaPackages({
   const versions = new Set(releases.map(({ version }) => version));
   assert(versions.size === 1, `Public package versions are not synchronized: ${[...versions].join(", ")}.`);
   const [version] = versions;
-  const tagsBefore = new Map();
-
-  for (const { name } of releases) tagsBefore.set(name, await registry.distTags(name));
 
   for (const release of releases) {
     const publishedVersions = await registry.versions(release.name);
-    if (publishedVersions.includes(release.version)) {
+    const isFresh = !publishedVersions.includes(release.version);
+
+    if (isFresh) {
+      await access(release.tarball);
+      process.stdout.write(`Publishing ${release.name}@${release.version} with the alpha dist-tag.\n`);
+      await registry.publishTarball(release.name, release.tarball, "alpha");
+    } else {
       process.stdout.write(`Skipping ${release.name}@${release.version}; it is already published.\n`);
-      continue;
     }
 
-    await access(release.tarball);
-    process.stdout.write(`Publishing ${release.name}@${release.version} with the alpha dist-tag.\n`);
-    await registry.publishTarball(release.name, release.tarball, "alpha");
-    await assertPublishedAtAlpha(registry, release.name, version, tagsBefore.get(release.name)?.latest, {
-      attempts: distTagAttempts,
-      delayMs: distTagDelayMs
-    });
+    await assertTagConverged(registry, release.name, "alpha", version, { attempts: distTagAttempts, delayMs: distTagDelayMs });
+    process.stdout.write(`Pointing ${release.name} latest=${version}.\n`);
+    await registry.setDistTag(release.name, version, "latest");
+    await assertTagConverged(registry, release.name, "latest", version, { attempts: distTagAttempts, delayMs: distTagDelayMs });
   }
 
-  process.stdout.write(`Verified all public packages at alpha=${version}; latest was unchanged.\n`);
+  process.stdout.write(`Verified all public packages at alpha=${version} and latest=${version}.\n`);
 }
 
 const npmRegistry = {
@@ -85,32 +84,27 @@ const npmRegistry = {
   },
   async publishTarball(_name, tarball, tag) {
     runNpm(["publish", tarball, "--tag", tag, "--access", "public"], "inherit");
+  },
+  async setDistTag(name, version, tag) {
+    runNpm(["dist-tag", "add", `${name}@${version}`, tag], "inherit");
   }
 };
 
-async function assertPublishedAtAlpha(registry, name, expected, latestBefore, { attempts, delayMs }) {
-  const latestOk = (tags) => tags.latest === latestBefore;
-  const alphaOk = (tags) => tags.alpha === expected;
+async function assertTagConverged(registry, name, tag, expected, { attempts, delayMs }) {
   let tags = {};
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     tags = await registry.distTags(name);
-    if (latestOk(tags)) {
-      if (alphaOk(tags)) return;
-      if (attempt < attempts) {
-        process.stdout.write(
-          `Waiting for ${name} dist-tag alpha to converge to ${expected} (attempt ${attempt}/${attempts}).\n`
-        );
-        await sleep(delayMs);
-      }
-      continue;
+    if (tags[tag] === expected) return;
+    if (attempt < attempts) {
+      process.stdout.write(
+        `Waiting for ${name} dist-tag ${tag} to converge to ${expected} (attempt ${attempt}/${attempts}).\n`
+      );
+      await sleep(delayMs);
     }
-    throw new Error(
-      `${name} changed latest from ${String(latestBefore)} to ${String(tags.latest)}.`
-    );
   }
 
-  throw new Error(`${name} has alpha=${String(tags.alpha)}; expected ${expected}.`);
+  throw new Error(`${name} has ${tag}=${String(tags[tag])}; expected ${expected}.`);
 }
 
 function runNpmJson(args) {

--- a/tests/release/package-manifests.test.ts
+++ b/tests/release/package-manifests.test.ts
@@ -61,7 +61,7 @@ describe("publishable package manifests", () => {
 
     await expect(access(join(root, "RELEASE_NOTES.md"))).rejects.toThrow();
     expect(releasing).toContain("bun run release:packages");
-    expect(releasing).toContain("protects the `latest` dist-tag");
+    expect(releasing).toContain("points `latest` at the newest published version");
     expect(releasing).toContain("Post-publication smoke tests");
     expect(releasing).toContain("npm view @scribe-sdk/react dist-tags");
     expect(releasing).not.toMatch(/\/home\/|\\Users\\|_authToken|npm_[A-Za-z0-9]{20,}|gh[pousr]_[A-Za-z0-9]{20,}/u);

--- a/tests/release/publish-packages.test.ts
+++ b/tests/release/publish-packages.test.ts
@@ -19,11 +19,14 @@ describe("alpha package publisher", () => {
     )).toBe(true);
   });
 
-  it("publishes missing tarballs explicitly to alpha with the CLI last", async () => {
+  it("publishes missing tarballs explicitly to alpha and points latest at the version", async () => {
     const root = await releaseFixture();
     const versions = new Map(publicPackages.map(({ name }) => [name, ["0.1.0-alpha.7"]]));
-    const tags = new Map(publicPackages.map(({ name }) => [name, { alpha: "0.1.0-alpha.7", latest: "0.1.0-alpha.4" }]));
+    const tags = new Map<string, { alpha: string; latest: string }>(
+      publicPackages.map(({ name }) => [name, { alpha: "0.1.0-alpha.7", latest: "0.1.0-alpha.4" }])
+    );
     const published: Array<{ name: string; tarball: string; tag: string }> = [];
+    const latestCalls: Array<{ name: string; version: string; tag: string }> = [];
 
     await publishAlphaPackages({
       root,
@@ -34,6 +37,11 @@ describe("alpha package publisher", () => {
           published.push({ name, tarball, tag });
           versions.get(name)?.push("0.1.0-alpha.8");
           tags.set(name, { alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" });
+        },
+        setDistTag: async (name, version, tag) => {
+          latestCalls.push({ name, version, tag });
+          const current = tags.get(name) ?? { alpha: "0.1.0-alpha.7", latest: "0.1.0-alpha.4" };
+          tags.set(name, { ...current, [tag]: version });
         }
       }
     });
@@ -46,30 +54,54 @@ describe("alpha package publisher", () => {
     ]);
     expect(published.every(({ tag }) => tag === "alpha")).toBe(true);
     expect(published.at(-1)?.tarball.endsWith("scribe-sdk-cli-0.1.0-alpha.8.tgz")).toBe(true);
+    expect(latestCalls.map(({ name }) => name)).toEqual([
+      "@scribe-sdk/styles",
+      "@scribe-sdk/react",
+      "@scribe-sdk/mdx",
+      "@scribe-sdk/cli"
+    ]);
+    expect(latestCalls.every(({ tag, version }) => tag === "latest" && version === "0.1.0-alpha.8")).toBe(true);
   });
 
-  it("skips versions that are already published", async () => {
+  it("skips already-published versions but still points latest at the version", async () => {
     const root = await releaseFixture();
     const publishTarball = async () => {
       throw new Error("already-published packages must not be republished");
     };
+    const latestCalls: Array<{ name: string; version: string; tag: string }> = [];
+    const tags = new Map<string, { alpha: string; latest: string }>(
+      publicPackages.map(({ name }) => [name, { alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" }])
+    );
 
-    await expect(publishAlphaPackages({
+    await publishAlphaPackages({
       root,
+      distTagAttempts: 3,
+      distTagDelayMs: 0,
       registry: {
         versions: async () => ["0.1.0-alpha.8"],
-        distTags: async () => ({ alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" }),
-        publishTarball
+        distTags: async (name) => tags.get(name) ?? {},
+        publishTarball,
+        setDistTag: async (name, version, tag) => {
+          latestCalls.push({ name, version, tag });
+          const current = tags.get(name) ?? { alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" };
+          tags.set(name, { ...current, [tag]: version });
+        }
       }
-    })).resolves.toBeUndefined();
+    });
+
+    expect(latestCalls).toHaveLength(publicPackages.length);
+    expect(latestCalls.every(({ version, tag }) => version === "0.1.0-alpha.8" && tag === "latest")).toBe(true);
   });
 
-  it("waits for the alpha dist-tag to converge after publishing", async () => {
+  it("waits for the alpha and then the latest dist-tag to converge after publishing", async () => {
     const root = await releaseFixture();
     const versions = new Map(publicPackages.map(({ name }) => [name, ["0.1.0-alpha.7"]]));
-    const tags = new Map(publicPackages.map(({ name }) => [name, { alpha: "0.1.0-alpha.7", latest: "0.1.0-alpha.4" }]));
+    const tags = new Map<string, { alpha: string; latest: string }>(
+      publicPackages.map(({ name }) => [name, { alpha: "0.1.0-alpha.7", latest: "0.1.0-alpha.4" }])
+    );
     const published: Array<{ name: string }> = [];
-    const postPublishReads = new Map(publicPackages.map(({ name }) => [name, 0]));
+    const alphaReads = new Map(publicPackages.map(({ name }) => [name, 0]));
+    const latestReads = new Map(publicPackages.map(({ name }) => [name, 0]));
 
     await publishAlphaPackages({
       root,
@@ -78,12 +110,19 @@ describe("alpha package publisher", () => {
       registry: {
         versions: async (name) => versions.get(name) ?? [],
         distTags: async (name) => {
-          const tag = tags.get(name) ?? {};
+          const tag = tags.get(name) ?? { alpha: "0.1.0-alpha.7", latest: "0.1.0-alpha.4" };
           const isPublished = published.some((entry) => entry.name === name);
-          if (isPublished) {
-            const n = (postPublishReads.get(name) ?? 0) + 1;
-            postPublishReads.set(name, n);
+          if (isPublished && tag.latest === "0.1.0-alpha.8") {
+            const n = (latestReads.get(name) ?? 0) + 1;
+            latestReads.set(name, n);
+            if (n < 2) return { ...tag, latest: "0.1.0-alpha.4" };
+            return tag;
+          }
+          if (isPublished && tag.alpha === "0.1.0-alpha.8" && tag.latest !== "0.1.0-alpha.8") {
+            const n = (alphaReads.get(name) ?? 0) + 1;
+            alphaReads.set(name, n);
             if (n < 2) return { ...tag, alpha: "0.1.0-alpha.7" };
+            return tag;
           }
           return tag;
         },
@@ -91,10 +130,15 @@ describe("alpha package publisher", () => {
           published.push({ name });
           versions.get(name)?.push("0.1.0-alpha.8");
           tags.set(name, { alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" });
+        },
+        setDistTag: async (name, version, tag) => {
+          const current = tags.get(name) ?? { alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" };
+          tags.set(name, { ...current, [tag]: version });
         }
       }
     });
-    expect(postPublishReads.get("@scribe-sdk/styles")).toBeGreaterThanOrEqual(2);
+    expect(alphaReads.get("@scribe-sdk/styles")).toBeGreaterThanOrEqual(2);
+    expect(latestReads.get("@scribe-sdk/styles")).toBeGreaterThanOrEqual(2);
     expect(published.map(({ name }) => name)).toEqual([
       "@scribe-sdk/styles",
       "@scribe-sdk/react",
@@ -103,9 +147,10 @@ describe("alpha package publisher", () => {
     ]);
   });
 
-  it("fails closed when the alpha dist-tag never converges", async () => {
+  it("fails closed when a dist-tag never converges", async () => {
     const root = await releaseFixture();
     const published: string[] = [];
+    const latest: string[] = [];
 
     await expect(publishAlphaPackages({
       root,
@@ -116,47 +161,35 @@ describe("alpha package publisher", () => {
         distTags: async () => ({ alpha: "0.1.0-alpha.7", latest: "0.1.0-alpha.4" }),
         publishTarball: async (name) => {
           published.push(name);
+        },
+        setDistTag: async (name, version) => {
+          latest.push(`${name}@${version}`);
         }
       }
     })).rejects.toThrow("has alpha=0.1.0-alpha.7; expected 0.1.0-alpha.8");
+
+    expect(latest).toHaveLength(0);
   });
 
-  it("fails closed when publication moves latest", async () => {
-    const root = await releaseFixture();
-    let published = false;
-
-    await expect(publishAlphaPackages({
-      root,
-      registry: {
-        versions: async () => published ? ["0.1.0-alpha.8"] : ["0.1.0-alpha.7"],
-        distTags: async () => ({
-          alpha: published ? "0.1.0-alpha.8" : "0.1.0-alpha.7",
-          latest: published ? "0.1.0-alpha.8" : "0.1.0-alpha.4"
-        }),
-        publishTarball: async () => {
-          published = true;
-        }
-      }
-    })).rejects.toThrow("changed latest");
-  });
-
-  it("does not publish later packages when the first package moves latest", async () => {
+  it("fails closed when the latest dist-tag cannot be moved to the published version", async () => {
     const root = await releaseFixture();
     const published: string[] = [];
 
     await expect(publishAlphaPackages({
       root,
+      distTagAttempts: 3,
+      distTagDelayMs: 0,
       registry: {
-        versions: async (name) => published.includes(name) ? ["0.1.0-alpha.8"] : [],
-        distTags: async (name) => ({
-          alpha: published.includes(name) ? "0.1.0-alpha.8" : "0.1.0-alpha.7",
-          latest: name === "@scribe-sdk/styles" && published.includes(name) ? "0.1.0-alpha.8" : "0.1.0-alpha.4"
-        }),
+        versions: async () => [],
+        distTags: async () => ({ alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" }),
         publishTarball: async (name) => {
           published.push(name);
+        },
+        setDistTag: async (_name, _version) => {
+          // latest stays behind: never converges to alpha.8
         }
       }
-    })).rejects.toThrow("changed latest");
+    })).rejects.toThrow("has latest=0.1.0-alpha.4; expected 0.1.0-alpha.8");
 
     expect(published).toEqual(["@scribe-sdk/styles"]);
   });
@@ -169,7 +202,8 @@ describe("alpha package publisher", () => {
       registry: {
         versions: async () => [],
         distTags: async () => ({}),
-        publishTarball: async () => undefined
+        publishTarball: async () => undefined,
+        setDistTag: async () => undefined
       }
     })).rejects.toThrow("alpha prerelease mode");
   });


### PR DESCRIPTION
## What

Changes the Release publisher so each publication repoints the `latest` dist-tag at the just-published `0.1.0-alpha.N` version (and waits for it to converge), instead of the old behavior that failed if `latest` moved (keeping it pinned at a stale `0.1.0-alpha.4`).

## Why

The npm package pages and tagless installs were misleading: they showed `latest = 0.1.0-alpha.4` while the newest published build was `0.1.0-alpha.9`. Now `latest` always reflects the current build.

## Changes

- `scripts/publish-alpha-packages.mjs`: publish to `alpha`, wait for convergence, then `npm dist-tag add <pkg>@<v> latest` and wait for that to converge. Removed the `assertPublishedAtAlpha` '`latest` must not move' guard.
- `scripts/publish-alpha-packages.d.mts`: added `setDistTag` to `PackageRegistry`.
- `tests/release/publish-packages.test.ts`: updated to assert `latest` is repointed and converges.
- `tests/release/package-manifests.test.ts`, `RELEASING.md`, plan doc: wording updated.

Verification: `bun run typecheck`, `bun run test` (295 passed), `bun run release:check` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Publishing now updates the `latest` tag to the newest alpha version.
  * Releases verify that both `alpha` and `latest` tags point to the expected version.
  * Existing package versions still receive necessary tag updates without republishing their contents.
  * Publishing retries tag updates and stops subsequent releases if convergence fails.

* **Documentation**
  * Updated release guidance and validation requirements to reflect the new `latest` tag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->