### PR TITLE
fix(release): keep trusted publishing alpha-only

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -72,14 +72,14 @@ The one-time command used to enter this cycle is:
 bunx changeset pre enter alpha
 ```
 
-Do not repeat it for each alpha. Add normal Changeset fragments during the cycle. `bunx changeset version` consumes new fragments and advances all fixed packages to the next `0.1.0-alpha.N` version. The prerelease tag for new versions is `alpha`, and `latest` is repointed at the newest published alpha after each publication so the public package pages and tagless installs reflect the current build.
+Do not repeat it for each alpha. Add normal Changeset fragments during the cycle. `bunx changeset version` consumes new fragments and advances all fixed packages to the next `0.1.0-alpha.N` version. The prerelease tag for new versions is `alpha`. After every package in a synchronized release is published and verified, an owner may promote `latest` manually so the public package pages and tagless installs reflect that build.
 
 ## Automated release path
 
 The `Release` GitHub Actions workflow runs only after the complete `CI` workflow succeeds for a push to `main`. It never runs for pull requests, failed CI, cancelled CI, or manually dispatched CI. The workflow has two deterministic outcomes:
 
 1. When unreleased Changeset fragments exist, it creates or updates the ready `changeset-release/main` version pull request, synchronizes package versions and changelogs, refreshes `bun.lock`, and dispatches CI for that exact release branch.
-2. When a verified version pull request has been merged and no unreleased fragments remain, it rebuilds and inspects the packages, then runs Scribe's guarded publisher. The publisher requires alpha prerelease mode, publishes each inspected tarball with an explicit `--tag alpha`, skips versions already on npm, publishes the CLI last, waits for each dist-tag to converge, and points `latest` at the newest published version.
+2. When a verified version pull request has been merged and no unreleased fragments remain, it rebuilds and inspects the packages, then runs Scribe's guarded publisher. The publisher requires alpha prerelease mode, publishes each inspected tarball with an explicit `--tag alpha`, skips versions already on npm, publishes the CLI last, and waits for each `alpha` dist-tag to converge.
 
 Publishing uses npm trusted publishing through GitHub OIDC. No npm write token, OTP, or `NODE_AUTH_TOKEN` belongs in GitHub secrets.
 
@@ -190,9 +190,9 @@ Changesets owns versioning and changelogs; it does not publish Scribe packages. 
 bun run release:packages
 ```
 
-The publisher verifies `.changeset/pre.json`, synchronized `0.1.0-alpha.N` manifests, and the npm dist-tags. It publishes only missing `.scribe-release/*.tgz` artifacts, explicitly passes `npm publish --tag alpha --access public`, waits for the `alpha` dist-tag to converge, then repoints `latest` at the published version and waits for that to converge too. npm authenticates the commands from the workflow's OIDC identity.
+The publisher verifies `.changeset/pre.json`, synchronized `0.1.0-alpha.N` manifests, and the npm dist-tags. It publishes only missing `.scribe-release/*.tgz` artifacts, explicitly passes `npm publish --tag alpha --access public`, and waits for the `alpha` dist-tag to converge. npm authenticates publication from the workflow's OIDC identity. The automated publisher does not mutate `latest`.
 
-Do not execute this command manually during ordinary release preparation. Manual publication remains an emergency fallback after diagnosing a failed automated release. Run it from an interactive terminal so npm can open its browser/passkey challenge; never paste a credential into the repository or CI logs. Publish tarballs in the documented order—styles, React, MDX, then CLI—and always include `--tag alpha --access public`. For each package, verify the `alpha` dist-tag resolves to the published version, then explicitly repoint `latest` with `npm dist-tag add @scribe-sdk/<name>@<version> latest` and verify `latest` resolves to that version before continuing, matching the publisher's convergence checks.
+Do not execute this command manually during ordinary release preparation. Manual publication remains an emergency fallback after diagnosing a failed automated release. Run it from an interactive terminal so npm can open its browser/passkey challenge; never paste a credential into the repository or CI logs. Publish tarballs in the documented order—styles, React, MDX, then CLI—and always include `--tag alpha --access public`. Verify every package's `alpha` dist-tag resolves to the synchronized release version before manually promoting `latest` for all four packages and verifying the promoted tags.
 
 ## Post-publication smoke tests
 

--- a/scripts/publish-alpha-packages.d.mts
+++ b/scripts/publish-alpha-packages.d.mts
@@ -7,7 +7,6 @@ export interface PackageRegistry {
   versions(name: PublicPackage["name"]): Promise<string[]>;
   distTags(name: PublicPackage["name"]): Promise<Record<string, string | undefined>>;
   publishTarball(name: PublicPackage["name"], tarball: string, tag: "alpha"): Promise<void>;
-  setDistTag(name: PublicPackage["name"], version: string, tag: "latest"): Promise<void>;
 }
 
 export const publicPackages: readonly PublicPackage[];

--- a/scripts/publish-alpha-packages.mjs
+++ b/scripts/publish-alpha-packages.mjs
@@ -66,12 +66,9 @@ export async function publishAlphaPackages({
     }
 
     await assertTagConverged(registry, release.name, "alpha", version, { attempts: distTagAttempts, delayMs: distTagDelayMs });
-    process.stdout.write(`Pointing ${release.name} latest=${version}.\n`);
-    await registry.setDistTag(release.name, version, "latest");
-    await assertTagConverged(registry, release.name, "latest", version, { attempts: distTagAttempts, delayMs: distTagDelayMs });
   }
 
-  process.stdout.write(`Verified all public packages at alpha=${version} and latest=${version}.\n`);
+  process.stdout.write(`Verified all public packages at alpha=${version}.\n`);
 }
 
 const npmRegistry = {
@@ -84,9 +81,6 @@ const npmRegistry = {
   },
   async publishTarball(_name, tarball, tag) {
     runNpm(["publish", tarball, "--tag", tag, "--access", "public"], "inherit");
-  },
-  async setDistTag(name, version, tag) {
-    runNpm(["dist-tag", "add", `${name}@${version}`, tag], "inherit");
   }
 };
 

--- a/tests/release/package-manifests.test.ts
+++ b/tests/release/package-manifests.test.ts
@@ -61,7 +61,7 @@ describe("publishable package manifests", () => {
 
     await expect(access(join(root, "RELEASE_NOTES.md"))).rejects.toThrow();
     expect(releasing).toContain("bun run release:packages");
-    expect(releasing).toContain("points `latest` at the newest published version");
+    expect(releasing).toContain("The automated publisher does not mutate `latest`");
     expect(releasing).toContain("Post-publication smoke tests");
     expect(releasing).toContain("npm view @scribe-sdk/react dist-tags");
     expect(releasing).not.toMatch(/\/home\/|\\Users\\|_authToken|npm_[A-Za-z0-9]{20,}|gh[pousr]_[A-Za-z0-9]{20,}/u);

--- a/tests/release/publish-packages.test.ts
+++ b/tests/release/publish-packages.test.ts
@@ -19,14 +19,13 @@ describe("alpha package publisher", () => {
     )).toBe(true);
   });
 
-  it("publishes missing tarballs explicitly to alpha and points latest at the version", async () => {
+  it("publishes missing tarballs explicitly to alpha", async () => {
     const root = await releaseFixture();
     const versions = new Map(publicPackages.map(({ name }) => [name, ["0.1.0-alpha.7"]]));
-    const tags = new Map<string, { alpha: string; latest: string }>(
-      publicPackages.map(({ name }) => [name, { alpha: "0.1.0-alpha.7", latest: "0.1.0-alpha.4" }])
+    const tags = new Map<string, { alpha: string }>(
+      publicPackages.map(({ name }) => [name, { alpha: "0.1.0-alpha.7" }])
     );
     const published: Array<{ name: string; tarball: string; tag: string }> = [];
-    const latestCalls: Array<{ name: string; version: string; tag: string }> = [];
 
     await publishAlphaPackages({
       root,
@@ -36,12 +35,7 @@ describe("alpha package publisher", () => {
         publishTarball: async (name, tarball, tag) => {
           published.push({ name, tarball, tag });
           versions.get(name)?.push("0.1.0-alpha.8");
-          tags.set(name, { alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" });
-        },
-        setDistTag: async (name, version, tag) => {
-          latestCalls.push({ name, version, tag });
-          const current = tags.get(name) ?? { alpha: "0.1.0-alpha.7", latest: "0.1.0-alpha.4" };
-          tags.set(name, { ...current, [tag]: version });
+          tags.set(name, { alpha: "0.1.0-alpha.8" });
         }
       }
     });
@@ -54,54 +48,44 @@ describe("alpha package publisher", () => {
     ]);
     expect(published.every(({ tag }) => tag === "alpha")).toBe(true);
     expect(published.at(-1)?.tarball.endsWith("scribe-sdk-cli-0.1.0-alpha.8.tgz")).toBe(true);
-    expect(latestCalls.map(({ name }) => name)).toEqual([
-      "@scribe-sdk/styles",
-      "@scribe-sdk/react",
-      "@scribe-sdk/mdx",
-      "@scribe-sdk/cli"
-    ]);
-    expect(latestCalls.every(({ tag, version }) => tag === "latest" && version === "0.1.0-alpha.8")).toBe(true);
   });
 
-  it("skips already-published versions but still points latest at the version", async () => {
+  it("skips an already-published package and continues with the remaining packages", async () => {
     const root = await releaseFixture();
-    const publishTarball = async () => {
-      throw new Error("already-published packages must not be republished");
-    };
-    const latestCalls: Array<{ name: string; version: string; tag: string }> = [];
-    const tags = new Map<string, { alpha: string; latest: string }>(
-      publicPackages.map(({ name }) => [name, { alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" }])
-    );
+    const versions = new Map(publicPackages.map(({ name }) => [
+      name,
+      name === "@scribe-sdk/styles" ? ["0.1.0-alpha.8"] : ["0.1.0-alpha.7"]
+    ]));
+    const published: string[] = [];
 
     await publishAlphaPackages({
       root,
       distTagAttempts: 3,
       distTagDelayMs: 0,
       registry: {
-        versions: async () => ["0.1.0-alpha.8"],
-        distTags: async (name) => tags.get(name) ?? {},
-        publishTarball,
-        setDistTag: async (name, version, tag) => {
-          latestCalls.push({ name, version, tag });
-          const current = tags.get(name) ?? { alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" };
-          tags.set(name, { ...current, [tag]: version });
+        versions: async (name) => versions.get(name) ?? [],
+        distTags: async () => ({ alpha: "0.1.0-alpha.8" }),
+        publishTarball: async (name) => {
+          published.push(name);
         }
       }
     });
 
-    expect(latestCalls).toHaveLength(publicPackages.length);
-    expect(latestCalls.every(({ version, tag }) => version === "0.1.0-alpha.8" && tag === "latest")).toBe(true);
+    expect(published).toEqual([
+      "@scribe-sdk/react",
+      "@scribe-sdk/mdx",
+      "@scribe-sdk/cli"
+    ]);
   });
 
-  it("waits for the alpha and then the latest dist-tag to converge after publishing", async () => {
+  it("waits for the alpha dist-tag to converge after publishing", async () => {
     const root = await releaseFixture();
     const versions = new Map(publicPackages.map(({ name }) => [name, ["0.1.0-alpha.7"]]));
-    const tags = new Map<string, { alpha: string; latest: string }>(
-      publicPackages.map(({ name }) => [name, { alpha: "0.1.0-alpha.7", latest: "0.1.0-alpha.4" }])
+    const tags = new Map<string, { alpha: string }>(
+      publicPackages.map(({ name }) => [name, { alpha: "0.1.0-alpha.7" }])
     );
     const published: Array<{ name: string }> = [];
     const alphaReads = new Map(publicPackages.map(({ name }) => [name, 0]));
-    const latestReads = new Map(publicPackages.map(({ name }) => [name, 0]));
 
     await publishAlphaPackages({
       root,
@@ -110,15 +94,9 @@ describe("alpha package publisher", () => {
       registry: {
         versions: async (name) => versions.get(name) ?? [],
         distTags: async (name) => {
-          const tag = tags.get(name) ?? { alpha: "0.1.0-alpha.7", latest: "0.1.0-alpha.4" };
+          const tag = tags.get(name) ?? { alpha: "0.1.0-alpha.7" };
           const isPublished = published.some((entry) => entry.name === name);
-          if (isPublished && tag.latest === "0.1.0-alpha.8") {
-            const n = (latestReads.get(name) ?? 0) + 1;
-            latestReads.set(name, n);
-            if (n < 2) return { ...tag, latest: "0.1.0-alpha.4" };
-            return tag;
-          }
-          if (isPublished && tag.alpha === "0.1.0-alpha.8" && tag.latest !== "0.1.0-alpha.8") {
+          if (isPublished && tag.alpha === "0.1.0-alpha.8") {
             const n = (alphaReads.get(name) ?? 0) + 1;
             alphaReads.set(name, n);
             if (n < 2) return { ...tag, alpha: "0.1.0-alpha.7" };
@@ -129,16 +107,11 @@ describe("alpha package publisher", () => {
         publishTarball: async (name) => {
           published.push({ name });
           versions.get(name)?.push("0.1.0-alpha.8");
-          tags.set(name, { alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" });
-        },
-        setDistTag: async (name, version, tag) => {
-          const current = tags.get(name) ?? { alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" };
-          tags.set(name, { ...current, [tag]: version });
+          tags.set(name, { alpha: "0.1.0-alpha.8" });
         }
       }
     });
     expect(alphaReads.get("@scribe-sdk/styles")).toBeGreaterThanOrEqual(2);
-    expect(latestReads.get("@scribe-sdk/styles")).toBeGreaterThanOrEqual(2);
     expect(published.map(({ name }) => name)).toEqual([
       "@scribe-sdk/styles",
       "@scribe-sdk/react",
@@ -150,7 +123,6 @@ describe("alpha package publisher", () => {
   it("fails closed when a dist-tag never converges", async () => {
     const root = await releaseFixture();
     const published: string[] = [];
-    const latest: string[] = [];
 
     await expect(publishAlphaPackages({
       root,
@@ -158,40 +130,12 @@ describe("alpha package publisher", () => {
       distTagDelayMs: 0,
       registry: {
         versions: async (name) => published.includes(name) ? ["0.1.0-alpha.8"] : [],
-        distTags: async () => ({ alpha: "0.1.0-alpha.7", latest: "0.1.0-alpha.4" }),
+        distTags: async () => ({ alpha: "0.1.0-alpha.7" }),
         publishTarball: async (name) => {
           published.push(name);
-        },
-        setDistTag: async (name, version) => {
-          latest.push(`${name}@${version}`);
         }
       }
     })).rejects.toThrow("has alpha=0.1.0-alpha.7; expected 0.1.0-alpha.8");
-
-    expect(latest).toHaveLength(0);
-  });
-
-  it("fails closed when the latest dist-tag cannot be moved to the published version", async () => {
-    const root = await releaseFixture();
-    const published: string[] = [];
-
-    await expect(publishAlphaPackages({
-      root,
-      distTagAttempts: 3,
-      distTagDelayMs: 0,
-      registry: {
-        versions: async () => [],
-        distTags: async () => ({ alpha: "0.1.0-alpha.8", latest: "0.1.0-alpha.4" }),
-        publishTarball: async (name) => {
-          published.push(name);
-        },
-        setDistTag: async (_name, _version) => {
-          // latest stays behind: never converges to alpha.8
-        }
-      }
-    })).rejects.toThrow("has latest=0.1.0-alpha.4; expected 0.1.0-alpha.8");
-
-    expect(published).toEqual(["@scribe-sdk/styles"]);
   });
 
   it("rejects release state that is not an alpha prerelease", async () => {
@@ -202,8 +146,7 @@ describe("alpha package publisher", () => {
       registry: {
         versions: async () => [],
         distTags: async () => ({}),
-        publishTarball: async () => undefined,
-        setDistTag: async () => undefined
+        publishTarball: async () => undefined
       }
     })).rejects.toThrow("alpha prerelease mode");
   });


### PR DESCRIPTION
## What changed

- remove automated `latest` dist-tag mutation from the alpha publisher
- keep OIDC publication explicit with `--tag alpha --access public`
- verify only `alpha` convergence while preserving idempotent skip behavior
- document manual `latest` promotion after every synchronized package is published

## Root cause

npm trusted publishing authorized `npm publish`, but the subsequent `npm dist-tag add` command returned `E401`. That stopped the release after styles alpha.10 was uploaded.

## Validation

- `bun run test:release` (52 tests passed)
- `git diff --check`
