### PR TITLE
fix(release): allow npm alpha tag propagation

### DIFF
--- a/scripts/publish-alpha-packages.mjs
+++ b/scripts/publish-alpha-packages.mjs
@@ -17,8 +17,8 @@ const defaultRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 export async function publishAlphaPackages({
   root = defaultRoot,
   registry = npmRegistry,
-  distTagAttempts = 12,
-  distTagDelayMs = 500
+  distTagAttempts = 60,
+  distTagDelayMs = 1_000
 } = {}) {
   assert(
     Number.isInteger(distTagAttempts) && distTagAttempts > 0,

--- a/tests/release/publish-packages.test.ts
+++ b/tests/release/publish-packages.test.ts
@@ -89,7 +89,6 @@ describe("alpha package publisher", () => {
 
     await publishAlphaPackages({
       root,
-      distTagAttempts: 3,
       distTagDelayMs: 0,
       registry: {
         versions: async (name) => versions.get(name) ?? [],
@@ -99,7 +98,7 @@ describe("alpha package publisher", () => {
           if (isPublished && tag.alpha === "0.1.0-alpha.8") {
             const n = (alphaReads.get(name) ?? 0) + 1;
             alphaReads.set(name, n);
-            if (n < 2) return { ...tag, alpha: "0.1.0-alpha.7" };
+            if (n < 13) return { ...tag, alpha: "0.1.0-alpha.7" };
             return tag;
           }
           return tag;
@@ -111,7 +110,7 @@ describe("alpha package publisher", () => {
         }
       }
     });
-    expect(alphaReads.get("@scribe-sdk/styles")).toBeGreaterThanOrEqual(2);
+    expect(alphaReads.get("@scribe-sdk/styles")).toBeGreaterThanOrEqual(13);
     expect(published.map(({ name }) => name)).toEqual([
       "@scribe-sdk/styles",
       "@scribe-sdk/react",


### PR DESCRIPTION
## What changed

- allow up to 60 seconds for npm's `alpha` dist-tag reads to converge after a successful publish
- retain fail-closed verification and the existing idempotent package ordering
- add a regression that remains stale for 12 reads before converging

## Root cause

`@scribe-sdk/react@0.1.0-alpha.10` published successfully with OIDC provenance, but npm continued returning `alpha.9` for longer than the previous polling window. The registry later converged to alpha.10.

## Validation

- `bun run typecheck`
- `node ./node_modules/typescript/bin/tsc --noEmit -p tsconfig.json`
- `bun run test:release` (52 tests passed)
- `git diff --check`
