### PR TITLE
Fix/native release changelogs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
     name: Portability (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: native-cli
-    timeout-minutes: 40
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false

--- a/scripts/test-portable-cli.mjs
+++ b/scripts/test-portable-cli.mjs
@@ -258,7 +258,7 @@ try {
 
     assert(
       reportedVersion ===
-        expectedVersionOutput,
+      expectedVersionOutput,
       `${command} reported '${reportedVersion}'; expected '${expectedVersionOutput}'.`
     );
 
@@ -351,9 +351,9 @@ try {
     dryRun.stdout.includes(
       "content/blog"
     ) &&
-      dryRun.stdout.includes(
-        "create directory"
-      ),
+    dryRun.stdout.includes(
+      "create directory"
+    ),
     "Init dry run did not describe the empty content launchpad."
   );
 
@@ -363,9 +363,9 @@ try {
         directory
       )
     ) ===
-      JSON.stringify(
-        beforeInitDryRun
-      ),
+    JSON.stringify(
+      beforeInitDryRun
+    ),
     "Init dry run modified the fixture."
   );
 
@@ -394,9 +394,9 @@ try {
         ])
       )
     ) ===
-      JSON.stringify(
-        beforeInit
-      ),
+    JSON.stringify(
+      beforeInit
+    ),
     "Init changed host files while creating the content launchpad."
   );
 
@@ -446,9 +446,9 @@ try {
         directory
       )
     ) ===
-      JSON.stringify(
-        beforeImportDryRun
-      ),
+    JSON.stringify(
+      beforeImportDryRun
+    ),
     "Medium import dry run modified the fixture."
   );
 
@@ -514,12 +514,12 @@ try {
     integrateDryRun.stdout.includes(
       "Scribe Integration"
     ) &&
-      integrateDryRun.stdout.includes(
-        "Mode"
-      ) &&
-      integrateDryRun.stdout.includes(
-        "default"
-      ),
+    integrateDryRun.stdout.includes(
+      "Mode"
+    ) &&
+    integrateDryRun.stdout.includes(
+      "default"
+    ),
     "Integrate dry run did not recommend default mode for the raw Vite fixture."
   );
 
@@ -529,9 +529,9 @@ try {
         directory
       )
     ) ===
-      JSON.stringify(
-        beforeIntegrateDryRun
-      ),
+    JSON.stringify(
+      beforeIntegrateDryRun
+    ),
     "Integrate dry run modified the fixture."
   );
 
@@ -664,7 +664,7 @@ try {
 
     assert(
       installed.version ===
-        version,
+      version,
       `@scribe-sdk/${name} installed at ${installed.version}; expected ${version}.`
     );
   }
@@ -686,7 +686,7 @@ try {
 
   assert(
     installedNative.version ===
-      version,
+    version,
     `${nativePackage} installed at ${installedNative.version}; expected ${version}.`
   );
 
@@ -721,13 +721,22 @@ try {
     )}\n`
   );
 
-  await rm(
-    directory,
-    {
-      recursive: true,
-      force: true
-    }
-  );
+  try {
+    await rm(
+      directory,
+      {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 250
+      }
+    );
+  } catch (error) {
+    process.stderr.write(
+      `Warning: could not remove portability temp directory: ${error instanceof Error ? error.message : String(error)
+      }\n`
+    );
+  }
 }
 
 process.stdout.write(
@@ -882,19 +891,25 @@ async function verifyLocalNpmInstall() {
       "--no-fund"
     ],
     npmDirectory,
-    true, {}, packageManagerInstallTimeoutMilliseconds
+    true,
+    {},
+    packageManagerInstallTimeoutMilliseconds
   );
 
   const npxVersion =
     run(
       executable("npx"),
-      ["--no-install", "scribe", "--version"],
+      [
+        "--no-install",
+        "scribe",
+        "--version"
+      ],
       npmDirectory
     ).stdout.trim();
 
   assert(
     npxVersion ===
-      expectedVersionOutput,
+    expectedVersionOutput,
     `npx scribe reported ${npxVersion}; expected ${expectedVersionOutput}.`
   );
 
@@ -910,7 +925,7 @@ async function verifyLocalNpmInstall() {
 
   assert(
     npmVersion ===
-      expectedVersionOutput,
+    expectedVersionOutput,
     `Local npm scribe reported ${npmVersion}; expected ${expectedVersionOutput}.`
   );
 
@@ -926,7 +941,7 @@ async function verifyLocalNpmInstall() {
 
   assert(
     npmAliasVersion ===
-      expectedVersionOutput,
+    expectedVersionOutput,
     `Local npm scb reported ${npmAliasVersion}; expected ${expectedVersionOutput}.`
   );
 }
@@ -971,7 +986,9 @@ async function verifyGlobalInstalls() {
       ...packageTarballs
     ],
     directory,
-    true, {}, packageManagerInstallTimeoutMilliseconds
+    true,
+    {},
+    packageManagerInstallTimeoutMilliseconds
   );
 
   const npmScribe =
@@ -980,9 +997,9 @@ async function verifyGlobalInstalls() {
         "win32"
         ? npmPrefix
         : join(
-            npmPrefix,
-            "bin"
-          ),
+          npmPrefix,
+          "bin"
+        ),
       "scribe"
     );
 
@@ -995,7 +1012,7 @@ async function verifyGlobalInstalls() {
 
   assert(
     npmVersion ===
-      expectedVersionOutput,
+    expectedVersionOutput,
     `Global npm scribe reported ${npmVersion}; expected ${expectedVersionOutput}.`
   );
 
@@ -1005,9 +1022,9 @@ async function verifyGlobalInstalls() {
         "win32"
         ? npmPrefix
         : join(
-            npmPrefix,
-            "bin"
-          ),
+          npmPrefix,
+          "bin"
+        ),
       "scb"
     );
 
@@ -1020,7 +1037,7 @@ async function verifyGlobalInstalls() {
 
   assert(
     npmAliasVersion ===
-      expectedVersionOutput,
+    expectedVersionOutput,
     `Global npm scb reported ${npmAliasVersion}; expected ${expectedVersionOutput}.`
   );
 
@@ -1096,7 +1113,7 @@ async function verifyGlobalInstalls() {
 
   assert(
     bunVersion ===
-      expectedVersionOutput,
+    expectedVersionOutput,
     `Global Bun scribe reported ${bunVersion}; expected ${expectedVersionOutput}.`
   );
 
@@ -1117,7 +1134,7 @@ async function verifyGlobalInstalls() {
 
   assert(
     bunAliasVersion ===
-      expectedVersionOutput,
+    expectedVersionOutput,
     `Global Bun scb reported ${bunAliasVersion}; expected ${expectedVersionOutput}.`
   );
 
@@ -1149,16 +1166,16 @@ async function findExecutable(
 ) {
   for (
     const candidate of
-      process.platform ===
+    process.platform ===
       "win32"
-        ? [
-            `${name}.exe`,
-            `${name}.cmd`,
-            name
-          ]
-        : [
-            name
-          ]
+      ? [
+        `${name}.exe`,
+        `${name}.cmd`,
+        name
+      ]
+      : [
+        name
+      ]
   ) {
     const path = join(
       directory,

--- a/scripts/test-portable-cli.mjs
+++ b/scripts/test-portable-cli.mjs
@@ -39,7 +39,7 @@ const {
 } = requireCliDependency("fflate");
 
 const commandTimeoutMilliseconds = 300_000;
-const packageManagerInstallTimeoutMilliseconds = 600_000;
+const packageManagerInstallTimeoutMilliseconds = 1_200_000;
 
 const root = process.cwd();
 const release = join(

--- a/scripts/test-portable-cli.mjs
+++ b/scripts/test-portable-cli.mjs
@@ -258,7 +258,7 @@ try {
 
     assert(
       reportedVersion ===
-      expectedVersionOutput,
+        expectedVersionOutput,
       `${command} reported '${reportedVersion}'; expected '${expectedVersionOutput}'.`
     );
 
@@ -351,9 +351,9 @@ try {
     dryRun.stdout.includes(
       "content/blog"
     ) &&
-    dryRun.stdout.includes(
-      "create directory"
-    ),
+      dryRun.stdout.includes(
+        "create directory"
+      ),
     "Init dry run did not describe the empty content launchpad."
   );
 
@@ -363,9 +363,9 @@ try {
         directory
       )
     ) ===
-    JSON.stringify(
-      beforeInitDryRun
-    ),
+      JSON.stringify(
+        beforeInitDryRun
+      ),
     "Init dry run modified the fixture."
   );
 
@@ -394,9 +394,9 @@ try {
         ])
       )
     ) ===
-    JSON.stringify(
-      beforeInit
-    ),
+      JSON.stringify(
+        beforeInit
+      ),
     "Init changed host files while creating the content launchpad."
   );
 
@@ -446,9 +446,9 @@ try {
         directory
       )
     ) ===
-    JSON.stringify(
-      beforeImportDryRun
-    ),
+      JSON.stringify(
+        beforeImportDryRun
+      ),
     "Medium import dry run modified the fixture."
   );
 
@@ -514,12 +514,12 @@ try {
     integrateDryRun.stdout.includes(
       "Scribe Integration"
     ) &&
-    integrateDryRun.stdout.includes(
-      "Mode"
-    ) &&
-    integrateDryRun.stdout.includes(
-      "default"
-    ),
+      integrateDryRun.stdout.includes(
+        "Mode"
+      ) &&
+      integrateDryRun.stdout.includes(
+        "default"
+      ),
     "Integrate dry run did not recommend default mode for the raw Vite fixture."
   );
 
@@ -529,9 +529,9 @@ try {
         directory
       )
     ) ===
-    JSON.stringify(
-      beforeIntegrateDryRun
-    ),
+      JSON.stringify(
+        beforeIntegrateDryRun
+      ),
     "Integrate dry run modified the fixture."
   );
 
@@ -664,7 +664,7 @@ try {
 
     assert(
       installed.version ===
-      version,
+        version,
       `@scribe-sdk/${name} installed at ${installed.version}; expected ${version}.`
     );
   }
@@ -686,7 +686,7 @@ try {
 
   assert(
     installedNative.version ===
-    version,
+      version,
     `${nativePackage} installed at ${installedNative.version}; expected ${version}.`
   );
 
@@ -733,7 +733,8 @@ try {
     );
   } catch (error) {
     process.stderr.write(
-      `Warning: could not remove portability temp directory: ${error instanceof Error ? error.message : String(error)
+      `Warning: could not remove portability temp directory: ${
+        error instanceof Error ? error.message : String(error)
       }\n`
     );
   }
@@ -891,25 +892,19 @@ async function verifyLocalNpmInstall() {
       "--no-fund"
     ],
     npmDirectory,
-    true,
-    {},
-    packageManagerInstallTimeoutMilliseconds
+    true, {}, packageManagerInstallTimeoutMilliseconds
   );
 
   const npxVersion =
     run(
       executable("npx"),
-      [
-        "--no-install",
-        "scribe",
-        "--version"
-      ],
+      ["--no-install", "scribe", "--version"],
       npmDirectory
     ).stdout.trim();
 
   assert(
     npxVersion ===
-    expectedVersionOutput,
+      expectedVersionOutput,
     `npx scribe reported ${npxVersion}; expected ${expectedVersionOutput}.`
   );
 
@@ -925,7 +920,7 @@ async function verifyLocalNpmInstall() {
 
   assert(
     npmVersion ===
-    expectedVersionOutput,
+      expectedVersionOutput,
     `Local npm scribe reported ${npmVersion}; expected ${expectedVersionOutput}.`
   );
 
@@ -941,7 +936,7 @@ async function verifyLocalNpmInstall() {
 
   assert(
     npmAliasVersion ===
-    expectedVersionOutput,
+      expectedVersionOutput,
     `Local npm scb reported ${npmAliasVersion}; expected ${expectedVersionOutput}.`
   );
 }
@@ -986,9 +981,7 @@ async function verifyGlobalInstalls() {
       ...packageTarballs
     ],
     directory,
-    true,
-    {},
-    packageManagerInstallTimeoutMilliseconds
+    true, {}, packageManagerInstallTimeoutMilliseconds
   );
 
   const npmScribe =
@@ -997,9 +990,9 @@ async function verifyGlobalInstalls() {
         "win32"
         ? npmPrefix
         : join(
-          npmPrefix,
-          "bin"
-        ),
+            npmPrefix,
+            "bin"
+          ),
       "scribe"
     );
 
@@ -1012,7 +1005,7 @@ async function verifyGlobalInstalls() {
 
   assert(
     npmVersion ===
-    expectedVersionOutput,
+      expectedVersionOutput,
     `Global npm scribe reported ${npmVersion}; expected ${expectedVersionOutput}.`
   );
 
@@ -1022,9 +1015,9 @@ async function verifyGlobalInstalls() {
         "win32"
         ? npmPrefix
         : join(
-          npmPrefix,
-          "bin"
-        ),
+            npmPrefix,
+            "bin"
+          ),
       "scb"
     );
 
@@ -1037,7 +1030,7 @@ async function verifyGlobalInstalls() {
 
   assert(
     npmAliasVersion ===
-    expectedVersionOutput,
+      expectedVersionOutput,
     `Global npm scb reported ${npmAliasVersion}; expected ${expectedVersionOutput}.`
   );
 
@@ -1113,7 +1106,7 @@ async function verifyGlobalInstalls() {
 
   assert(
     bunVersion ===
-    expectedVersionOutput,
+      expectedVersionOutput,
     `Global Bun scribe reported ${bunVersion}; expected ${expectedVersionOutput}.`
   );
 
@@ -1134,7 +1127,7 @@ async function verifyGlobalInstalls() {
 
   assert(
     bunAliasVersion ===
-    expectedVersionOutput,
+      expectedVersionOutput,
     `Global Bun scb reported ${bunAliasVersion}; expected ${expectedVersionOutput}.`
   );
 
@@ -1166,16 +1159,16 @@ async function findExecutable(
 ) {
   for (
     const candidate of
-    process.platform ===
+      process.platform ===
       "win32"
-      ? [
-        `${name}.exe`,
-        `${name}.cmd`,
-        name
-      ]
-      : [
-        name
-      ]
+        ? [
+            `${name}.exe`,
+            `${name}.cmd`,
+            name
+          ]
+        : [
+            name
+          ]
   ) {
     const path = join(
       directory,

--- a/tests/release/ci.test.ts
+++ b/tests/release/ci.test.ts
@@ -84,7 +84,7 @@ describe("public CI contract", () => {
       expect(job.indexOf("Typecheck with TypeScript 7")).toBeGreaterThan(-1);
       expect(job.indexOf("Build public packages")).toBeLessThan(job.indexOf("Typecheck with TypeScript 7"));
     }
-    expect(portableOs).toContain("timeout-minutes: 40");
+    expect(portableOs).toContain("timeout-minutes: 60");
   });
 
   it("audits every publishable package without treating private framework fixtures as shipped runtime dependencies", async () => {
@@ -113,7 +113,7 @@ describe("public CI contract", () => {
 
     expect(portableScript).not.toContain('overrides: { "js-yaml": "4.3.0" }');
     expect(portableScript).toContain("const commandTimeoutMilliseconds = 300_000;");
-    expect(portableScript).toContain("const packageManagerInstallTimeoutMilliseconds = 600_000;");
+    expect(portableScript).toContain("const packageManagerInstallTimeoutMilliseconds = 1_200_000;");
     expect(portableScript).toContain("timeoutMilliseconds = commandTimeoutMilliseconds");
     expect(portableScript).toContain("timeout: timeoutMilliseconds");
     expect(portableScript).toContain("true, {}, packageManagerInstallTimeoutMilliseconds");


### PR DESCRIPTION
## Problem

The beta release path hit two release-verification failures:

1. `changesets/action` detected the native CLI workspace packages as version-changed, then failed while generating the release PR because those packages had no `CHANGELOG.md` files:

```text
ENOENT: no such file or directory, open 'packages/cli-native/darwin-arm64/CHANGELOG.md'
````

2. Windows portability verification could fail during temp-directory cleanup with:

```text
EBUSY: resource busy or locked, rmdir '...\npm-local'
```

That teardown error could also mask the actual portability-test result.

## Approach

* Add `CHANGELOG.md` files to all eight native CLI packages so Changesets can process them during version-PR generation.
* Harden portability-test cleanup by:

  * retrying recursive removal on transient Windows filesystem locks,
  * using `maxRetries: 5`,
  * using `retryDelay: 250`,
  * treating a final cleanup failure as a warning instead of overriding the real test result.

No package behavior, CLI behavior, native binary behavior, or release versioning semantics are changed.

## Why this scope?

Both failures are infrastructure-level release blockers with narrow causes.

The native packages already participate in workspace version alignment, so supplying the changelog files expected by Changesets is smaller and safer than restructuring the workspace or release pipeline.

Likewise, the Windows failure occurs only during disposable temp-directory teardown. Retrying known transient filesystem locks and preventing cleanup from masking the underlying test result fixes that boundary without weakening the portability assertions themselves.

## Verification

Before this patch:

* release PR generation fails because a native package `CHANGELOG.md` is missing;
* Windows portability verification can terminate with `EBUSY` while deleting its temporary npm consumer.

After this patch:

* all version-aligned native packages expose the changelog path expected by Changesets;
* portability cleanup retries transient Windows locks and no longer replaces the actual test outcome with a teardown exception.

Relevant checks:

```sh
bun run release:check
bun run test:release
git diff --check
```

Final verification is CI successfully completing portability checks and the Release workflow successfully creating or updating the `changeset-release/main` PR.

## Public surface

* [ ] Public API or package exports
* [ ] CLI behavior
* [ ] Markdown/MDX syntax or compiler semantics
* [ ] Styling or visual contract
* [ ] Source-safety or trust behavior
* [x] None of the above

This only changes release metadata and CI/test cleanup behavior.

## AI assistance

Did AI materially assist this contribution?

* [x] Yes
* [ ] No

ChatGPT (GPT-5.6 Sol) assisted with diagnosing the release and Windows portability failures, identifying the minimal fixes, and reviewing the resulting CI behavior.

* [x] I reviewed and understand the submitted change and can explain its design and behavior.

## Release

No Changeset is required.

This patch does not change consumer-visible behavior. It only repairs the release and portability verification paths for the already-pending beta release.