### PR TITLE
fix(release): sync the Rust crate version on every changeset bump

### DIFF
--- a/scripts/version-packages.mjs
+++ b/scripts/version-packages.mjs
@@ -2,7 +2,8 @@ import { spawnSync } from "node:child_process";
 
 run("bunx", ["changeset", "version"]);
 run("bun", ["install"]);
-await alignNativePackages();
+const version = await alignNativePackages();
+await alignRustCrate(version);
 
 
 async function alignNativePackages() {
@@ -29,6 +30,41 @@ async function alignNativePackages() {
   }
   await writeFile(join(root, "packages/cli/package.json"), `${JSON.stringify(cli, null, 2)}\n`);
   run("bun", ["install"]);
+  return cli.version;
+}
+
+async function alignRustCrate(version) {
+  // The release job that runs this script does not install a Rust
+  // toolchain, so keep Cargo.toml and Cargo.lock in sync with plain
+  // text edits instead of shelling out to `cargo`. scribe-cli is the
+  // workspace's only member and a private, unpublished path package,
+  // so its version stamp is not referenced anywhere else in either
+  // file.
+  const { readFile, writeFile } = await import("node:fs/promises");
+  const { join } = await import("node:path");
+  const root = process.cwd();
+
+  const cargoTomlPath = join(root, "Cargo.toml");
+  const cargoToml = await readFile(cargoTomlPath, "utf8");
+  const updatedCargoToml = cargoToml.replace(
+    /^version = "[^"]+"$/mu,
+    `version = "${version}"`
+  );
+  if (updatedCargoToml === cargoToml) {
+    throw new Error("Could not find the workspace package version in Cargo.toml.");
+  }
+  await writeFile(cargoTomlPath, updatedCargoToml);
+
+  const cargoLockPath = join(root, "Cargo.lock");
+  const cargoLock = await readFile(cargoLockPath, "utf8");
+  const updatedCargoLock = cargoLock.replace(
+    /(name = "scribe-cli"\nversion = )"[^"]+"/u,
+    `$1"${version}"`
+  );
+  if (updatedCargoLock === cargoLock) {
+    throw new Error("Could not find the scribe-cli entry in Cargo.lock.");
+  }
+  await writeFile(cargoLockPath, updatedCargoLock);
 }
 
 function run(command, args) {


### PR DESCRIPTION
## Problem
Every automated version-bump PR that changesets/action opens has been failing `release:check` in CI (and therefore has been unmergeable, and publishing has never advanced past 0.1.0-alpha.10 on npm) with:

```
Error: Rust CLI version 0.1.0-beta does not match 0.1.0-beta.0.
```

`scripts/version-packages.mjs` bumps the four npm package manifests and the staged native packages through `changeset version`, but never touched `Cargo.toml`/`Cargo.lock`. The workspace crate version was only ever set manually (in the commit that introduced the Rust CLI, and the one that prepared 0.1.0-beta). The first time the automated bump ran since the Rust rewrite, it advanced npm to `0.1.0-beta.0` while the crate stayed at `0.1.0-beta", tripping the alignment check on PR #46 and blocking it from merging (which is also what has been silently blocking every attempt to actually publish a beta release).

## Approach
Add `alignRustCrate()` to `version-packages.mjs`, called right after the npm packages are aligned. It rewrites the `version` field in `Cargo.toml` and the `scribe-cli` entry in `Cargo.lock` via plain text substitution (no `cargo` invocation), because the `release` job in `release.yml` has no Rust toolchain installed. `scribe-cli` is the workspace's only member and an unpublished path package, so its version stamp is not referenced anywhere else in either file.

## Why this scope?
Minimal, targeted fix in the one script responsible for version alignment. No workflow or CI changes needed since `changesets/action` already stages and commits every file the version script modifies.

## Verification
- Manually reproduced: bumped `Cargo.toml` to `0.1.0-beta.0` and ran `cargo build --locked -p scribe-cli` — failed exactly like CI ("cannot update the lock file ... --locked was passed").
- Applied the same regex substitution used in the fix against copies of `Cargo.toml`/`Cargo.lock`, then re-ran `cargo build --locked -p scribe-cli` — passed, with `Cargo.lock`'s `scribe-cli` entry correctly updated.
- `bun run test` (307/307 passing, including `tests/release/changesets.test.ts`)
- `bun run release:check` (passes against current, unchanged main state)
- `cargo fmt --check`
- `git diff --check` (no whitespace issues)

## Follow-up
Once this merges, the next `Release` run will regenerate PR #46 (`chore(release): version packages (beta)`) with a matching Rust version, unblocking it.