### PR TITLE
fix(ci): force LF line endings to prevent CRLF in native artifacts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary


### PR DESCRIPTION
## Root cause

CI on `main` (after merging #47) failed at the **'Check repository whitespace'** step in the `Release verification (Linux)` job: `git diff --check` flagged `packages/cli-native/darwin-arm64/LICENSE` for trailing whitespace.

- The repo had **no `.gitattributes`**, so the Windows runner's checkout produced **CRLF** text files.
- The `native-cli` job uploads the entire `packages/cli-native` tree (`ci.yml` uploads `path: packages/cli-native`), so the Windows MSVC artifacts carried CRLF versions of the shared committed files (202 `\r` bytes in LICENSE).
- `verify-linux` downloads all `native-*` artifacts with `merge-multiple: true` (`ci.yml:138-143`), and the nondeterministic overwrite order clobbered the committed LF files with the CRLF ones — tripping `git diff --check`. Flaky: #47's PR CI passed but the main push failed.

## Fix

Add `.gitattributes` with `* text=auto eol=lf` (plus binary patterns). This forces LF on all checkouts (including Windows), so native artifacts never introduce CRLF.

Verified: `git add --renormalize .` produces no diff — all committed files are already LF, so zero churn.