### PR TITLE
fix(test): tolerate native platform packages in changesets initial versions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary

--- a/tests/release/changesets.test.ts
+++ b/tests/release/changesets.test.ts
@@ -34,7 +34,9 @@ describe("Changesets release policy", () => {
     expect(pre.mode).toBe("pre");
     expect(pre.tag).toBe("beta");
     expect(fragmentIds).toEqual(expect.arrayContaining([...pre.changesets].sort()));
-    expect(pre.initialVersions).toEqual(Object.fromEntries(publicPackages.map((name) => [name, "0.1.0-alpha.10"])));
+    for (const name of publicPackages) {
+      expect(pre.initialVersions[name]).toBe("0.1.0-alpha.10");
+    }
   });
 
   it("records one curated bootstrap fragment for the first public prerelease", async () => {


### PR DESCRIPTION
## Problem

The changesets version PR (`changeset-release/main`, #46) fails CI at `tests/release/changesets.test.ts:37`:

```js
expect(pre.initialVersions).toEqual(
  Object.fromEntries(publicPackages.map((name) => [name, "0.1.0-alpha.10"]))
);
```

`publicPackages` covers only the 4 core packages (react/styles/mdx/cli), but once changesets versions the native platform packages, `pre.json`'s `initialVersions` also gains 8 keys (`@scribe-sdk/cli-darwin-*`, `@scribe-sdk/cli-*linux-*`, `@scribe-sdk/cli-win32-*`). The strict `toEqual` fails, making the version PR unmergeable and blocking the release.

`main` passes locally only because `pre.json` currently holds the 4 base keys; the version PR adds the platform keys and trips the assertion.

## Fix

Assert the public-package subset instead of exact object equality, so the test is robust to changesets adding native platform entries:

```js
for (const name of publicPackages) {
  expect(pre.initialVersions[name]).toBe("0.1.0-alpha.10");
}
```

This keeps the guarantee that the 4 public packages started from alpha.10 without failing on added native keys.

Verified: `bunx vitest run tests/release/changesets.test.ts` -> 7/7 pass.