### PR TITLE
perf(ci): cache dependencies and skip npm portability smoke on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,14 @@ jobs:
           path: packages/cli-native
           merge-multiple: true
 
+      - name: Restore dependency cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: bun-deps-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-deps-${{ runner.os }}-
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
@@ -245,6 +253,14 @@ jobs:
           path: packages/cli-native
           merge-multiple: true
 
+      - name: Restore dependency cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: bun-deps-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-deps-${{ runner.os }}-
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
@@ -309,6 +325,14 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.13"
+
+      - name: Restore dependency cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: bun-deps-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-deps-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/scripts/test-portable-cli.mjs
+++ b/scripts/test-portable-cli.mjs
@@ -690,7 +690,10 @@ try {
     `${nativePackage} installed at ${installedNative.version}; expected ${version}.`
   );
 
-  await verifyLocalNpmInstall();
+  if (process.platform !== "win32") {
+    await verifyLocalNpmInstall();
+  }
+
   await verifyGlobalInstalls();
 } finally {
   await mkdir(
@@ -969,90 +972,92 @@ async function verifyGlobalInstalls() {
       "npm-global"
     );
 
-  run(
-    executable("npm"),
-    [
-      "install",
-      "--global",
-      "--prefix",
-      npmPrefix,
-      "--no-audit",
-      "--no-fund",
-      ...packageTarballs
-    ],
-    directory,
-    true, {}, packageManagerInstallTimeoutMilliseconds
-  );
-
-  const npmScribe =
-    await findExecutable(
-      process.platform ===
-        "win32"
-        ? npmPrefix
-        : join(
-            npmPrefix,
-            "bin"
-          ),
-      "scribe"
-    );
-
-  const npmVersion =
+  if (process.platform !== "win32") {
     run(
-      npmScribe,
-      ["--version"],
-      directory
-    ).stdout.trim();
-
-  assert(
-    npmVersion ===
-      expectedVersionOutput,
-    `Global npm scribe reported ${npmVersion}; expected ${expectedVersionOutput}.`
-  );
-
-  const npmAlias =
-    await findExecutable(
-      process.platform ===
-        "win32"
-        ? npmPrefix
-        : join(
-            npmPrefix,
-            "bin"
-          ),
-      "scb"
-    );
-
-  const npmAliasVersion =
-    run(
-      npmAlias,
-      ["--version"],
-      directory
-    ).stdout.trim();
-
-  assert(
-    npmAliasVersion ===
-      expectedVersionOutput,
-    `Global npm scb reported ${npmAliasVersion}; expected ${expectedVersionOutput}.`
-  );
-
-  const npmGlobalBare =
-    run(
-      npmScribe,
-      [],
+      executable("npm"),
+      [
+        "install",
+        "--global",
+        "--prefix",
+        npmPrefix,
+        "--no-audit",
+        "--no-fund",
+        ...packageTarballs
+      ],
       directory,
-      false
+      true, {}, packageManagerInstallTimeoutMilliseconds
     );
 
-  assert(
-    npmGlobalBare.status === 0,
-    `Global npm scribe without arguments exited ${npmGlobalBare.status}; expected 0.`
-  );
+    const npmScribe =
+      await findExecutable(
+        process.platform ===
+          "win32"
+          ? npmPrefix
+          : join(
+              npmPrefix,
+              "bin"
+            ),
+        "scribe"
+      );
 
-  assert(
-    npmGlobalBare.stdout.includes(
-      "Scribe is not integrated here."
-    ),
-    "Global npm scribe did not delegate to print the project integration state."
-  );
+    const npmVersion =
+      run(
+        npmScribe,
+        ["--version"],
+        directory
+      ).stdout.trim();
+
+    assert(
+      npmVersion ===
+        expectedVersionOutput,
+      `Global npm scribe reported ${npmVersion}; expected ${expectedVersionOutput}.`
+    );
+
+    const npmAlias =
+      await findExecutable(
+        process.platform ===
+          "win32"
+          ? npmPrefix
+          : join(
+              npmPrefix,
+              "bin"
+            ),
+        "scb"
+      );
+
+    const npmAliasVersion =
+      run(
+        npmAlias,
+        ["--version"],
+        directory
+      ).stdout.trim();
+
+    assert(
+      npmAliasVersion ===
+        expectedVersionOutput,
+      `Global npm scb reported ${npmAliasVersion}; expected ${expectedVersionOutput}.`
+    );
+
+    const npmGlobalBare =
+      run(
+        npmScribe,
+        [],
+        directory,
+        false
+      );
+
+    assert(
+      npmGlobalBare.status === 0,
+      `Global npm scribe without arguments exited ${npmGlobalBare.status}; expected 0.`
+    );
+
+    assert(
+      npmGlobalBare.stdout.includes(
+        "Scribe is not integrated here."
+      ),
+      "Global npm scribe did not delegate to print the project integration state."
+    );
+  }
 
   const bunHome = join(
     directory,


### PR DESCRIPTION
## What
Two CI speedups targeting the critical path.

### 1. Dependency caching
Added `actions/cache@v4` for `node_modules`, keyed on `runner.os` + `bun.lock` hash, to the three JS jobs (verify-linux, portable-os ×3, browser-engines ×2).

`oven-sh/setup-bun` only caches the Bun *binary* (keyed on download URL) — it does not cache dependencies. So every job was re-downloading deps from scratch each run. A cache miss/failure is never worse than today because `bun install --frozen-lockfile` still runs idempotently after restore.

### 2. Bun-only portability on Windows
Gated the two real-`npm install` smoke sections of `scripts/test-portable-cli.mjs` (`verifyLocalNpmInstall` + the npm-global part of `verifyGlobalInstalls`) behind `process.platform !== "win32"`. The bun global smoke test still runs on all platforms.

## Why
Measured from run `31913188069`:
| Step | Windows | Linux | macOS |
|---|---|---|---|
| Install deps (bun) | 1.1m | 0.1m | 0.2m |
| **smoke-test CLI** | **13.0m** | 1.0m | 1.6m |

The Windows `test:portability` step is 13 minutes of real `npm install` on a cold Windows runner — the CI critical path (`Portability (windows-latest)` = 14.9m of an ~18-21m run). Restricting it to bun drops that job toward ~3-4m, moving the run ceiling to `Release verification (Linux)` at ~6m.

## Tests
- `bun run test:release` → 10 files, 70 tests pass
- `node --check` on the modified script
- YAML parses; CI whitespace check passes