### PR TITLE
fix(cli): default Studio port when omitted; promote newest publish to latest

### DIFF
--- a/.changeset/polite-studios-launch.md
+++ b/.changeset/polite-studios-launch.md
@@ -1,0 +1,5 @@
+---
+"@scribe-sdk/cli": patch
+---
+
+Start Scribe Studio with the default loopback port when none is provided, so `scribe studio init` and `scribe studio <article>` launch without requiring `--port`; omit or null ports are treated as the default instead of an error.

--- a/packages/cli/src/engine.test.ts
+++ b/packages/cli/src/engine.test.ts
@@ -5,6 +5,8 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
+import { resolveStudioPort } from "./engine.js";
+
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const workspaceRoot = resolve(packageRoot, "../..");
 const engineSource = resolve(packageRoot, "src/engine.ts");
@@ -92,6 +94,18 @@ describe("engine protocol", () => {
     expect(object(object(initialize.result).result).protocolVersion).toBe(1);
     expect(Array.isArray(events) ? events : []).toHaveLength(3);
     expect(Array.isArray(failures) ? failures : []).toHaveLength(2);
+  });
+
+  it("uses the default Studio port when none or null is provided", () => {
+    expect(resolveStudioPort(undefined)).toBe(4317);
+    expect(resolveStudioPort(null)).toBe(4317);
+  });
+
+  it("validates explicit Studio ports", () => {
+    expect(resolveStudioPort(8080)).toBe(8080);
+    expect(() => resolveStudioPort(0)).toThrow(/integer from 1 to 65535/);
+    expect(() => resolveStudioPort(70_000)).toThrow(/integer from 1 to 65535/);
+    expect(() => resolveStudioPort("4317")).toThrow(/integer from 1 to 65535/);
   });
 });
 

--- a/packages/cli/src/engine.ts
+++ b/packages/cli/src/engine.ts
@@ -567,7 +567,7 @@ async function runStudioSession(
     mode = resolution.mode;
     modeReason = resolution.reason;
   }
-  const port = params.port === undefined ? 4317 : requiredPort(params.port);
+  const port = resolveStudioPort(params.port);
   const hostCss = optionalString(params.hostCss);
   emitEvent(operationId, "task.started", { task: "Start Studio" });
   const handle = await startStudio({
@@ -576,7 +576,7 @@ async function runStudioSession(
     mode,
     modeReason,
     port,
-    strictPort: params.port !== undefined,
+    strictPort: params.port !== undefined && params.port !== null,
     open: params.noOpen !== true,
     ...(hostCss === undefined ? {} : { hostCss })
   });
@@ -622,6 +622,11 @@ function requiredPort(value: unknown): number {
     throw rpcFailure(-32_602, "port must be an integer from 1 to 65535.", "usage");
   }
   return value;
+}
+
+export function resolveStudioPort(port: unknown): number {
+  if (port === undefined || port === null) return 4317;
+  return requiredPort(port);
 }
 
 

--- a/scripts/publish-prerelease-packages.d.mts
+++ b/scripts/publish-prerelease-packages.d.mts
@@ -27,6 +27,7 @@ export interface PackageRegistry {
   versions(name: PublicPackage["name"]): Promise<string[]>;
   distTags(name: PublicPackage["name"]): Promise<Record<string, string | undefined>>;
   publishTarball(name: PublicPackage["name"], tarball: string, tag: "alpha" | "beta"): Promise<void>;
+  setDistTag(name: PublicPackage["name"], version: string, tag: string): Promise<void>;
 }
 
 export const nativePackages: readonly NativePackage[];

--- a/scripts/publish-prerelease-packages.mjs
+++ b/scripts/publish-prerelease-packages.mjs
@@ -68,9 +68,11 @@ export async function publishPrereleasePackages({
     }
 
     await assertTagConverged(registry, release.name, channel, version, { attempts: distTagAttempts, delayMs: distTagDelayMs });
+    await registry.setDistTag(release.name, version, "latest");
+    await assertTagConverged(registry, release.name, "latest", version, { attempts: distTagAttempts, delayMs: distTagDelayMs });
   }
 
-  process.stdout.write(`Verified all public packages at ${channel}=${version}.\n`);
+  process.stdout.write(`Verified all public packages at ${channel}=${version} and latest=${version}.\n`);
 }
 
 const npmRegistry = {
@@ -83,6 +85,9 @@ const npmRegistry = {
   },
   async publishTarball(_name, tarball, tag) {
     runNpm(["publish", tarball, "--tag", tag, "--access", "public"], "inherit");
+  },
+  async setDistTag(name, version, tag) {
+    runNpm(["dist-tag", "add", `${name}@${version}`, tag], "inherit");
   }
 };
 

--- a/tests/release/publish-packages.test.ts
+++ b/tests/release/publish-packages.test.ts
@@ -22,10 +22,11 @@ describe("prerelease package publisher", () => {
   it("publishes every missing package explicitly to beta without moving alpha", async () => {
     const root = await releaseFixture();
     const versions = new Map(publicPackages.map(({ name }) => [name, ["0.1.0-alpha.10"]]));
-    const tags = new Map<string, { alpha: string; beta: string }>(
+    const tags = new Map<string, { alpha: string; beta: string; latest: string }>(
       publicPackages.map(({ name }) => [name, {
         alpha: "0.1.0-alpha.10",
-        beta: "0.1.0-alpha.10"
+        beta: "0.1.0-alpha.10",
+        latest: "0.1.0-alpha.10"
       }])
     );
     const published: Array<{ name: string; tarball: string; tag: string }> = [];
@@ -38,8 +39,12 @@ describe("prerelease package publisher", () => {
         publishTarball: async (name, tarball, tag) => {
           published.push({ name, tarball, tag });
           versions.get(name)?.push("0.1.0-beta");
-          const previous = tags.get(name) as { alpha: string; beta: string };
+          const previous = tags.get(name) as { alpha: string; beta: string; latest: string };
           tags.set(name, { ...previous, beta: "0.1.0-beta" });
+        },
+        setDistTag: async (name, version, tag) => {
+          const previous = tags.get(name) as { alpha: string; beta: string; latest: string };
+          tags.set(name, { ...previous, [tag]: version });
         }
       }
     });
@@ -48,6 +53,7 @@ describe("prerelease package publisher", () => {
     expect(published.every(({ tag }) => tag === "beta")).toBe(true);
     expect(published.at(-1)?.tarball.endsWith("scribe-sdk-cli-0.1.0-beta.tgz")).toBe(true);
     expect([...tags.values()].every(({ alpha }) => alpha === "0.1.0-alpha.10")).toBe(true);
+    expect([...tags.values()].every(({ latest }) => latest === "0.1.0-beta")).toBe(true);
   });
 
   it("skips published packages and fails closed when beta never converges", async () => {
@@ -66,7 +72,8 @@ describe("prerelease package publisher", () => {
         }),
         publishTarball: async (name) => {
           published.push(name);
-        }
+        },
+        setDistTag: async () => undefined
       }
     })).rejects.toThrow("has beta=0.1.0-alpha.10; expected 0.1.0-beta");
   });
@@ -80,8 +87,9 @@ describe("prerelease package publisher", () => {
       root: alphaRoot,
       registry: {
         versions: async () => ["0.1.0-alpha.10"],
-        distTags: async () => ({ alpha: "0.1.0-alpha.10" }),
-        publishTarball: async () => undefined
+        distTags: async () => ({ alpha: "0.1.0-alpha.10", latest: "0.1.0-alpha.10" }),
+        publishTarball: async () => undefined,
+        setDistTag: async () => undefined
       }
     })).resolves.toBeUndefined();
 
@@ -95,7 +103,8 @@ describe("prerelease package publisher", () => {
         registry: {
           versions: async () => [],
           distTags: async () => ({}),
-          publishTarball: async () => undefined
+          publishTarball: async () => undefined,
+          setDistTag: async () => undefined
         }
       })).rejects.toThrow("alpha or beta prerelease mode");
     }


### PR DESCRIPTION
## What
- **Bug fix:** `scribe studio init` / `scribe studio <article>` no longer fail with `port must be an integer from 1 to 65535` when no `--port` is passed. Rust sends `port: null` (from `Option<u16>` → `None`), which the engine misread as a provided-but-invalid port. `resolveStudioPort` now treats `undefined`/`null` as the default `4317` (engine.ts:570).
- **Release:** the publish script now also sets the npm `latest` dist-tag to the freshly published version, so `@latest` resolves to the newest beta instead of lingering on `alpha.10`.

## Tests
- Added regression tests for `resolveStudioPort` (`null`/omitted → default; invalid ports rejected).
- Updated publish-package tests to cover `latest` convergence.
- Full suite: 300 unit tests, 61 release tests, typecheck clean.