### PR TITLE
chore: add changesets for the Ctrl+C fix and boxed panels

### DIFF
--- a/.changeset/bold-frames-arrange.md
+++ b/.changeset/bold-frames-arrange.md
@@ -1,0 +1,5 @@
+---
+"@scribe-sdk/cli": minor
+---
+
+Render `scribe studio init` and every plan/apply command (`init`, `integrate`, `import`, `update`) inside labeled boxed panels — `ARTICLE DETAILS` around the studio-init prompts, `REVIEW & CONFIRM` around the plan summary and apply confirmation, and `RUN` around the live event stream and receipt — instead of an unbroken scroll of text. Falls back to today's plain rendering on narrow or non-interactive terminals.

--- a/.changeset/quiet-storms-mend.md
+++ b/.changeset/quiet-storms-mend.md
@@ -1,0 +1,5 @@
+---
+"@scribe-sdk/cli": patch
+---
+
+Fix the native CLI crashing with a raw `EPIPE` stack trace when Ctrl+C was pressed during a running Studio session: the engine already shut Studio down gracefully on SIGINT, but the CLI had no signal handler of its own and died on the raw signal before the engine could finish, tearing the pipe out from under it. A second Ctrl+C still exits immediately. Also fixes long status values (like a lockfile-conflict message) breaking the label/value grid instead of wrapping with a hanging indent, and replaces the unstyled interactive prompts with ones matching the rest of the CLI's visual grammar.


### PR DESCRIPTION
## Summary
- #58 and #59 merged straight to main without a Changeset, so the next automated version bump would have shipped both the EPIPE/Ctrl+C fix and the boxed-panels rendering with no changelog entry describing either.
- Backfills both now, alongside the 18 already-queued changesets from earlier work, so everything gets a real description on the next release.

This does not bump any version or publish anything itself — merging it only means the *next* `changeset-release/main` version PR (created automatically by the Release workflow) will include these two entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)