### PR TITLE
chore: add changeset for the boxed article-details TUI form

### DIFF
--- a/.changeset/tidy-hounds-rescue.md
+++ b/.changeset/tidy-hounds-rescue.md
@@ -1,0 +1,5 @@
+---
+"@scribe-sdk/cli": minor
+---
+
+Render `scribe studio init`'s article-details collection as a real inline TUI form instead of a sequence of scrollback-append prompts: the complete bordered box (all fields, derived slug/path defaults) exists from the first frame, arrow keys and Tab/Shift+Tab move freely between fields, and the real cursor is positioned inside whichever field is focused.


### PR DESCRIPTION
## Summary
PR #62 (the ratatui TUI form rewrite for `scribe studio init`) merged without a changeset, so it would have shipped in the next version bump with no changelog entry.

This only adds the missing changelog entry — no version bump, no publish, on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)