### PR TITLE
fix(cli): park the boxed form's cursor below its box before finishing

### DIFF
--- a/.changeset/eight-moons-sparkle.md
+++ b/.changeset/eight-moons-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@scribe-sdk/cli": patch
+---
+
+Fix `scribe studio init`'s boxed forms rendering with overlapping, stacked borders when moving from the title form into the slug/path form and on into the plan review — the form never parked the terminal cursor below its own box before finishing, so whatever rendered next started from a cursor position still inside the previous box instead of a clean line beneath it.

--- a/crates/scribe-cli/src/terminal.rs
+++ b/crates/scribe-cli/src/terminal.rs
@@ -904,9 +904,16 @@ pub fn run_boxed_form<E>(
     }
 
     let field_count = fields.len();
+    // Borders (2) + one field row each + a dedicated blank row *below* the
+    // box, reserved the same way the splash reserves `CURSOR_ROWS`: without
+    // it, the real terminal cursor is left wherever the last focused field
+    // was — inside the box — and whatever renders next (another form, the
+    // next boxed panel) starts from there instead of a clean line below,
+    // producing overlapping borders.
     let height = u16::try_from(field_count)
         .unwrap_or(u16::MAX)
-        .saturating_add(2);
+        .saturating_add(2)
+        .saturating_add(CURSOR_ROWS);
 
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::with_options(
@@ -923,7 +930,9 @@ pub fn run_boxed_form<E>(
     let mut frontier = 0usize;
 
     let outcome: Result<FormOutcome, E> = loop {
-        if let Err(error) = draw_form_frame(&mut terminal, tag, fields, focused, capabilities) {
+        if let Err(error) =
+            draw_form_frame(&mut terminal, tag, fields, focused, capabilities, false)
+        {
             break Err(to_error(error));
         }
 
@@ -961,6 +970,13 @@ pub fn run_boxed_form<E>(
         }
     };
 
+    // One last draw with the cursor moved to the reserved resting row below
+    // the box, so whatever writes next starts from a clean, known line
+    // instead of wherever the last focused field happened to be. Best
+    // effort: `outcome` is already decided, and failing to tidy the cursor
+    // shouldn't mask that result.
+    let _ = draw_form_frame(&mut terminal, tag, fields, focused, capabilities, true);
+
     disable_raw_mode().map_err(&to_error)?;
     terminal.show_cursor().map_err(&to_error)?;
 
@@ -973,12 +989,16 @@ fn draw_form_frame(
     fields: &[FormField],
     focused: usize,
     capabilities: Capabilities,
+    resting: bool,
 ) -> io::Result<()> {
     terminal
         .draw(|frame| {
             let full_area = frame.area();
             let width = full_area.width.min(66);
-            let area = Rect::new(full_area.x, full_area.y, width, full_area.height);
+            let box_height = u16::try_from(fields.len())
+                .unwrap_or(u16::MAX)
+                .saturating_add(2);
+            let area = Rect::new(full_area.x, full_area.y, width, box_height);
 
             let block = Block::default()
                 .borders(Borders::ALL)
@@ -996,7 +1016,7 @@ fn draw_form_frame(
                 .constraints(vec![Constraint::Length(1); fields.len()])
                 .split(inner);
 
-            let mut cursor = None;
+            let mut focus_cursor = None;
 
             for (index, field) in fields.iter().enumerate() {
                 let label = format!("{:<LABEL_WIDTH$}  ", field.label);
@@ -1021,9 +1041,15 @@ fn draw_form_frame(
                     let x = rows[index].x
                         + u16::try_from(label.chars().count()).unwrap_or(0)
                         + u16::try_from(field.buffer.chars().count()).unwrap_or(0);
-                    cursor = Some((x, rows[index].y));
+                    focus_cursor = Some((x, rows[index].y));
                 }
             }
+
+            let cursor = if resting {
+                Some((area.x, area.y + area.height))
+            } else {
+                focus_cursor
+            };
 
             if let Some((x, y)) = cursor {
                 frame.set_cursor_position((x, y));


### PR DESCRIPTION
## Summary
Real bug from a screenshot: `scribe studio init`'s boxed forms rendered with overlapping, stacked box borders — a second "ARTICLE DETAILS" header appearing on top of the first, `REVIEW & CONFIRM`'s border overlapping the slug/path form's border.

Root cause: `run_boxed_form` never moved the terminal cursor below its own box before returning — it finished with the cursor wherever the last focused field's row was, *inside* the box. Whatever rendered next (the next form, or the plain `write_box_top` call for `REVIEW & CONFIRM`) started writing from that cursor position instead of a clean line beneath it, corrupting the layout. The splash screen already avoids this exact problem by reserving a dedicated blank `CURSOR_ROWS` row and parking the cursor there on its final frame — the form never got that treatment.

## Fix
Reserves the same kind of dedicated resting row below the form's box, and does one final draw with the cursor explicitly moved there (`resting: bool` param on `draw_form_frame`) before disabling raw mode and returning.

## Verification note
My first verification pass used a pty harness with a **hardcoded DSR response** (always reporting a fixed cursor row) — that's exactly the kind of test that would look fine for a single box and miss a multi-box sequencing bug like this one, since ratatui queries the real cursor position fresh for every `Terminal::with_options` call. Rebuilt the harness to track the true cursor position live via `pyte` and answer DSR queries accurately, then dumped full scrollback (not just the visible screen) across the whole flow: title form → slug/path form → REVIEW & CONFIRM. Every box now starts immediately after the previous one's closing border, with no gap and no overlap.

## Test plan
- [x] `cargo test -p scribe-cli` — 44 tests, unchanged (this fix doesn't touch tested logic, only cursor placement)
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings`, `cargo fmt --check`, `cargo test --workspace`, `git diff --check`
- [x] Live-drove the compiled release binary through a pty with accurate live cursor tracking (not a static DSR hack) and confirmed via full scrollback reconstruction that all three boxes (title form, slug/path form, REVIEW & CONFIRM) render sequentially with zero overlap
- [x] No crash/EPIPE in the raw session log

🤖 Generated with [Claude Code](https://claude.com/claude-code)